### PR TITLE
Doc update to maybe help with install error

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Here's a more full-fledged example, still using `#kaocha {}`.
  ;; will make sure are loaded. When providing a vector of symbols, or pointing
  ;; at a var containing a vector, then kaocha will call all referenced functions
  ;; for reporting.
- :reporter    kaocha.report/documentation}}
+ :reporter    kaocha.report/documentation}
 ```
 
 All these configuration keys have default values, shown above, so you can omit most of them, including `:tests`.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Here's a more full-fledged example, still using `#kaocha {}`.
 
           ;; Regex patterns to determine whether a namespace contains
           ;; tests.
-          :ns-patterns [#"-test$"]}]
+          :ns-patterns ["-test$"]}]
 
  :plugins [:kaocha.plugin/print-invocations]
 

--- a/doc/02_installing.md
+++ b/doc/02_installing.md
@@ -22,7 +22,9 @@ In `deps.edn`, create a `test` "alias" (profile) that loads the `lambdaisland/ka
 ;; deps.edn
 {:deps { ,,, }
  :aliases
- {:test {:deps {lambdaisland/kaocha {:mvn/version "0.0-122"}}}}}
+ {:test
+  {:extra-deps {lambdaisland/kaocha {:mvn/version "0.0-122"}}
+   :main-opts  ["-m" "kaocha.runner"]}}}
 ```
 
 Other dependencies that are only used for tests like test framework or assertion


### PR DESCRIPTION
Hello, trying to give `kaocha` a whirl and I ran into the following exception when going through the instructions on the `install` doc. They differ from the install instructions on the `README`, and when I use the `README` docs I the error goes away.
Caveat, I know nothing about clojure deps.edn, so my suggested changes may be wrong.

```
clojure -A:test --print-config
Error building classpath. nil
java.lang.NullPointerException
	at clojure.core$update.invokeStatic(core.clj:6118)
	at clojure.core$update.invoke(core.clj:6108)
	at clojure.tools.deps.alpha$merge_alias_maps$fn__1002$fn__1004.invoke(alpha.clj:40)
	at clojure.core.protocols$iter_reduce.invokeStatic(protocols.clj:49)
	at clojure.core.protocols$fn__7839.invokeStatic(protocols.clj:75)
	at clojure.core.protocols$fn__7839.invoke(protocols.clj:75)
	at clojure.core.protocols$fn__7781$G__7776__7794.invoke(protocols.clj:13)
	at clojure.core$reduce.invokeStatic(core.clj:6748)
	at clojure.core$reduce.invoke(core.clj:6730)
	at clojure.tools.deps.alpha$merge_alias_maps$fn__1002.invoke(alpha.clj:39)
	at clojure.lang.ArrayChunk.reduce(ArrayChunk.java:58)
	at clojure.core.protocols$fn__7847.invokeStatic(protocols.clj:136)
	at clojure.core.protocols$fn__7847.invoke(protocols.clj:124)
	at clojure.core.protocols$fn__7807$G__7802__7816.invoke(protocols.clj:19)
	at clojure.core.protocols$seq_reduce.invokeStatic(protocols.clj:31)
	at clojure.core.protocols$fn__7833.invokeStatic(protocols.clj:75)
	at clojure.core.protocols$fn__7833.invoke(protocols.clj:75)
	at clojure.core.protocols$fn__7781$G__7776__7794.invoke(protocols.clj:13)
	at clojure.core$reduce.invokeStatic(core.clj:6748)
	at clojure.core$reduce.invoke(core.clj:6730)
	at clojure.tools.deps.alpha$merge_alias_maps.invokeStatic(alpha.clj:38)
	at clojure.tools.deps.alpha$merge_alias_maps.doInvoke(alpha.clj:35)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.core$apply.invokeStatic(core.clj:657)
	at clojure.core$apply.invoke(core.clj:652)
	at clojure.tools.deps.alpha$combine_aliases.invokeStatic(alpha.clj:50)
	at clojure.tools.deps.alpha$combine_aliases.invoke(alpha.clj:44)
	at clojure.tools.deps.alpha.script.make_classpath$create_classpath.invokeStatic(make_classpath.clj:57)
	at clojure.tools.deps.alpha.script.make_classpath$create_classpath.invoke(make_classpath.clj:52)
	at clojure.tools.deps.alpha.script.make_classpath$run.invokeStatic(make_classpath.clj:70)
	at clojure.tools.deps.alpha.script.make_classpath$run.invoke(make_classpath.clj:64)
	at clojure.tools.deps.alpha.script.make_classpath$_main.invokeStatic(make_classpath.clj:109)
	at clojure.tools.deps.alpha.script.make_classpath$_main.doInvoke(make_classpath.clj:84)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:702)
	at clojure.core$apply.invokeStatic(core.clj:657)
	at clojure.main$main_opt.invokeStatic(main.clj:317)
	at clojure.main$main_opt.invoke(main.clj:313)
	at clojure.main$main.invokeStatic(main.clj:424)
	at clojure.main$main.doInvoke(main.clj:387)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:702)
	at clojure.main.main(main.java:37)
```