### PR TITLE
Cloverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ shared_steps: &shared_steps
   - run: java -version
   - run: clojure -e '(println (clojure-version))'
   - run: clojure -A:dev:test:junit-xml${EXTRA_ALIASES} -m kaocha.runner --reporter documentation --plugin junit-xml --plugin cloverage --coveralls --junit-xml-file test-results/kaocha/results.xml
+  - run: head target/coverage/coveralls.json
   - run: curl -F 'json_file=@target/coverage/coveralls.json' https://coveralls.io/api/v1/jobs
   - store_test_results:
       path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ shared_steps: &shared_steps
   - run: java -version
   - run: clojure -e '(println (clojure-version))'
   - run: clojure -A:dev:test:junit-xml${EXTRA_ALIASES} -m kaocha.runner --reporter documentation --plugin junit-xml --plugin cloverage --coveralls --junit-xml-file test-results/kaocha/results.xml
+  - run: curl -F 'json_file=@target/coverage/coveralls.json' https://coveralls.io/api/v1/jobs
   - store_test_results:
       path: test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,8 @@ shared_steps: &shared_steps
   - run: mkdir -p test-results/kaocha
   - run: java -version
   - run: clojure -e '(println (clojure-version))'
-  - run: clojure -A:dev:test:junit-xml${EXTRA_ALIASES} -m kaocha.runner --reporter documentation --plugin junit-xml --plugin cloverage --coveralls --junit-xml-file test-results/kaocha/results.xml
-  - run: head target/coverage/coveralls.json
-  - run: curl -F 'json_file=@target/coverage/coveralls.json' https://coveralls.io/api/v1/jobs
+  - run: clojure -A:dev:test:junit-xml${EXTRA_ALIASES} -m kaocha.runner --reporter documentation --plugin junit-xml --plugin cloverage --codecov --junit-xml-file test-results/kaocha/results.xml
+  - run: curl -s https://codecov.io/bash | bash -s - -f target/coverage/codecov.json
   - store_test_results:
       path: test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ shared_steps: &shared_steps
   - run: mkdir -p test-results/kaocha
   - run: java -version
   - run: clojure -e '(println (clojure-version))'
-  - run: clojure -A:dev:test:junit-xml${EXTRA_ALIASES} -m kaocha.runner --reporter documentation --plugin junit-xml --junit-xml-file test-results/kaocha/results.xml
+  - run: clojure -A:dev:test:junit-xml${EXTRA_ALIASES} -m kaocha.runner --reporter documentation --plugin junit-xml --plugin cloverage --coveralls --junit-xml-file test-results/kaocha/results.xml
   - store_test_results:
       path: test-results
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources"]
 
  :deps
- {org.clojure/clojure          {:mvn/version "1.10.0-beta4"}
+ {org.clojure/clojure          {:mvn/version "1.10.0-beta5"}
   org.clojure/spec.alpha       {:mvn/version "0.2.176"}
   org.clojure/tools.cli        {:mvn/version "0.4.1"}
   lambdaisland/tools.namespace {:mvn/version "0.0-228"}
@@ -16,7 +16,11 @@
   aero                         {:mvn/version "1.1.3"}
   progrock                     {:mvn/version "0.1.2"}
   io.aviso/pretty              {:mvn/version "0.1.35"}
-  meta-merge                   {:mvn/version "1.0.0"}}
+  meta-merge                   {:mvn/version "1.0.0"}
+
+  ;; used by cloverage. Prevent core.async from pulling in an old version
+  org.clojure/tools.reader {:mvn/version "1.3.2"}
+  cloverage                {:mvn/version "1.0.13"}}
 
  :aliases
  {:test

--- a/src/kaocha/cloverage.clj
+++ b/src/kaocha/cloverage.clj
@@ -1,9 +1,0 @@
-(ns kaocha.cloverage
-  #_(:require [cloverage.coverage :as c]
-              [kaocha.runner :as runner]))
-
-#_
-(defmethod c/runner-fn :kaocha [_]
-  (fn [_]
-    (merge {:errors 0}
-           (t/run (runner/config {})))))

--- a/src/kaocha/plugin/cloverage.clj
+++ b/src/kaocha/plugin/cloverage.clj
@@ -104,6 +104,13 @@
                (contains? opts :cov-ns-exclude-regex)
                (assoc :ns-exclude-regex (map re-pattern (:cov-ns-exclude-regex opts)))))))
 
+(defn run-cloverage [opts]
+  ;; Compatibility with future versions
+  (let [arity (count (first (:arglists (meta #'c/run-main))))]
+    (case arity
+      1 (c/run-main [opts])
+      2 (c/run-main [opts] {}))))
+
 (defplugin kaocha.plugin/cloverage
   (cli-options [opts]
     (into opts (map #(into [nil] %)) cli-opts))
@@ -130,7 +137,7 @@
                                 :test-ns-path test-paths
                                 ::config config)]
         (run! cp/add-classpath test-paths)
-        (throw+ {:kaocha/early-exit (c/run-main [opts] {})})))))
+        (throw+ {:kaocha/early-exit (run-cloverage opts)})))))
 
 (defmethod c/runner-fn :kaocha [opts]
   (fn [_test-nses]

--- a/src/kaocha/plugin/cloverage.clj
+++ b/src/kaocha/plugin/cloverage.clj
@@ -1,37 +1,143 @@
 (ns kaocha.plugin.cloverage
-  #_(:require [bultitude.core :as blt]
-              [clojure.java.io :as io]
-              [clojure.set :as set]
-              [clojure.test :as test]
-              [clojure.tools.cli :as cli]
-              [clojure.test.junit :as junit]
-              [clojure.tools.logging :as log]
-              [cloverage.debug :as debug]
-              [cloverage.dependency :as dep]
-              [cloverage.instrument :as inst]
-              [cloverage.report :as rep]
-              [cloverage.report.console :as console]
-              [cloverage.report.coveralls :as coveralls]
-              [cloverage.report.codecov :as codecov]
-              [cloverage.report.emma-xml :as emma-xml]
-              [cloverage.report.html :as html]
-              [cloverage.report.lcov :as lcov]
-              [cloverage.report.raw :as raw]
-              [cloverage.report.text :as text]
-              [cloverage.source :as src])
-  (:import clojure.lang.IObj))
+  (:require [clojure.string :as str]
+            [cloverage.coverage :as c]
+            [kaocha.api :as api]
+            [kaocha.plugin :as plugin :refer [defplugin]]
+            [kaocha.result :as result]
+            [kaocha.classpath :as cp]
+            [slingshot.slingshot :refer [throw+]]))
 
-#_
+(defn accumulate [m k v]
+  (update m k (fnil conj []) v))
+
+(def default-opts
+  {:output "target/coverage"
+   :text? false
+   :html? true
+   :emma-xml? false
+   :lcov? false
+   :codecov? false
+   :coveralls? false
+   :summary? true
+   :fail-threshold 0
+   :low-watermark 50
+   :high-watermark 80
+   :nop? false
+   :ns-regex []
+   :ns-exclude-regex []})
+
+(def cli-opts
+  [["--cov-output" "Cloverage output directory."]
+   ["--[no-]cov-text" "Produce a text report."]
+   ["--[no-]cov-html" "Produce a HTML report."]
+   ["--[no-]emma-xml"
+    "Produce an EMMA XML report. [emma.sourceforge.net]"]
+   ["--[no-]lcov"
+    "Produce a lcov/gcov report."]
+   ["--[no-]codecov"
+    "Generate a JSON report for Codecov.io"]
+   ["--[no-]coveralls"
+    "Send a JSON report to Coveralls if on a CI server"]
+   ["--[no-]cov-summary"
+    "Prints a summary"]
+   ["--cov-fail-threshold PERCENT"
+    "Sets the percentage threshold at which cloverage will abort the build. Default: 0%"
+    :parse-fn #(Integer/parseInt %)]
+   ["--cov-low-watermark PERCENT"
+    "Sets the low watermark percentage (valid values 0..100). Default: 50%"
+    :parse-fn #(Integer/parseInt %)]
+   ["--cov-high-watermark PERCENT"
+    "Sets the high watermark percentage (valid values 0..100). Default: 80%"
+    :parse-fn #(Integer/parseInt %)]
+   ["--[no-]cov-nop" "Instrument with noops."]
+   ["--cov-ns-regex REGEX"
+    "Regex for instrumented namespaces (can be repeated)."
+    :assoc-fn accumulate]
+   ["--cov-ns-exclude-regex REGEX"
+    "Regex for namespaces not to be instrumented (can be repeated)."
+    :assoc-fn accumulate]])
+
+(defn update-config [config]
+  (let [opts (:kaocha/cli-options config)]
+    (update config
+            :cloverage/opts
+            #(cond-> (merge default-opts %)
+               (contains? opts :cov-output)
+               (assoc :output (:cov-output opts))
+
+               (contains? opts :cov-text)
+               (assoc :text? (:cov-text opts))
+
+               (contains? opts :cov-html)
+               (assoc :html? (:cov-html opts))
+
+               (contains? opts :emma-xml)
+               (assoc :emma-xml? (:emma-xml opts))
+
+               (contains? opts :lcov)
+               (assoc :lcov? (:lcov opts))
+
+               (contains? opts :codecov)
+               (assoc :codecov? (:codecov opts))
+
+               (contains? opts :coveralls)
+               (assoc :coveralls? (:coveralls opts))
+
+               (contains? opts :cov-summary)
+               (assoc :summary? (:cov-summary opts))
+
+               (contains? opts :cov-fail-threshold)
+               (assoc :fail-threshold (:cov-fail-threshold opts))
+
+               (contains? opts :cov-low-watermark)
+               (assoc :low-watermark (:cov-low-watermark opts))
+
+               (contains? opts :cov-high-watermark)
+               (assoc :high-watermark (:cov-high-watermark opts))
+
+               (contains? opts :cov-nop)
+               (assoc :nop? (:cov-nop opts))
+
+               (contains? opts :cov-ns-regex)
+               (assoc :ns-regex (map re-pattern (:cov-ns-regex opts)))
+
+               (contains? opts :cov-ns-exclude-regex)
+               (assoc :ns-exclude-regex (map re-pattern (:cov-ns-exclude-regex opts)))))))
+
 (defplugin kaocha.plugin/cloverage
   (cli-options [opts]
-               (conj opts
-                     [nil "--[no]-cloverage" "Enable cloverage." :default true]
-                     [nil "--cloverage-output" "Cloverage output directory." :default "target/coverage"]))
+    (into opts (map #(into [nil] %)) cli-opts))
+
+  ;; The config hook only gets called inside api/run, which is too late for us,
+  ;; so update-config also gets called explicitly in `main`. Calling
+  ;; update-config here anyway so people can see the result of option merging
+  ;; with --print-config. It's a bit of duplicated work though, we might have to
+  ;; rethink this to make people implementing custom `main` hooks able to still
+  ;; use `config` hooks.
 
   (config [config]
-          (if-let [output (get-in config [:kaocha/cli-options :cloverage-output])]
-            (assoc config ::output output)
-            config))
+    (update-config config))
 
+  (main [config]
+    (binding [c/*exit-after-test* false]
+      (let [config       (update-config config)
+            suites       (remove :kaocha.testable/skip (:kaocha/tests config))
+            source-paths (mapcat :kaocha/source-paths suites)
+            test-paths   (mapcat :kaocha/test-paths suites)
+            opts         (assoc (:cloverage/opts config)
+                                :runner :kaocha
+                                :src-ns-path source-paths
+                                :test-ns-path test-paths
+                                ::config config)]
+        (run! cp/add-classpath test-paths)
+        (throw+ {:kaocha/early-exit (c/run-main [opts] {})})))))
 
-  )
+(defmethod c/runner-fn :kaocha [opts]
+  (fn [_test-nses]
+    (let [result (->> (::config opts)
+                      api/run
+                      (plugin/run-hook :kaocha.hooks/post-summary)
+                      :kaocha.result/tests
+                      result/totals)]
+      {:errors (+ (::result/error result)
+                  (::result/fail result))})))

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -138,9 +138,11 @@
             (min (+ (:kaocha.result/error totals) (:kaocha.result/fail totals)) 255))
 
           :else
-          (let [result (plugin/run-hook :kaocha.hooks/post-summary (api/run config))
-                totals (result/totals (:kaocha.result/tests result))]
-            (min (+ (:kaocha.result/error totals) (:kaocha.result/fail totals)) 255)))))))
+          (do
+            (plugin/run-hook :kaocha.hooks/main config)
+            (let [result (plugin/run-hook :kaocha.hooks/post-summary (api/run config))
+                  totals (result/totals (:kaocha.result/tests result))]
+              (min (+ (:kaocha.result/error totals) (:kaocha.result/fail totals)) 255))))))))
 
 (defn- exit-process! [code]
   (System/exit code))
@@ -148,5 +150,5 @@
 (defn -main [& args]
   (try+
    (exit-process! (apply -main* args))
-   (catch :kaocha/early-exit {:kaocha/keys [exit-code]}
-     (exit-process! -3))))
+   (catch :kaocha/early-exit {exit-code :kaocha/early-exit}
+     (exit-process! exit-code))))

--- a/src/kaocha/type/var.clj
+++ b/src/kaocha/type/var.clj
@@ -19,11 +19,13 @@
     (println (str/join " " testing-contexts)))
   (println "Test ran without assertions. Did you forget an (is ...)?"))
 
-(defmethod testable/-run :kaocha.type/var [{:kaocha.var/keys [var test wrap] :as testable} test-plan]
+(defmethod testable/-run :kaocha.type/var [{:kaocha.var/keys [test wrap]
+                                            the-var :kaocha.var/var
+                                            :as testable} test-plan]
   (type/with-report-counters
     (let [test (reduce #(%2 %1) test wrap)]
-      (binding [t/*testing-vars* (conj t/*testing-vars* var)]
-        (t/do-report {:type :begin-test-var, :var var})
+      (binding [t/*testing-vars* (conj t/*testing-vars* the-var)]
+        (t/do-report {:type :begin-test-var, :var the-var})
         (try
           (test)
           (catch clojure.lang.ExceptionInfo e
@@ -43,7 +45,7 @@
         (when (= pass error fail pending 0)
           (binding [testable/*fail-fast?* false]
             (t/do-report {:type ::zero-assertions})))
-        (t/do-report {:type :end-test-var, :var var})
+        (t/do-report {:type :end-test-var, :var the-var})
         (merge testable {:kaocha.result/count 1} (type/report-count))))))
 
 (s/def :kaocha.type/var (s/keys :req [:kaocha.testable/type


### PR DESCRIPTION
This integrates Kaocha with Cloverage through a plugin. This will be pulled out
into its own repo so as not to impose the extra dependency on people, but I'm
committing it here first to try it out on CI.

This introduces an extra `:main` hook that plugins can use to have their own
top-level behavior. They can shortcut any remaining activity by throwing
:kaocha/early-exit.

The plugin makes most Cloverage options accessible through both command line
arguments and tests.edn. Test and source paths are taken from test suite
configurations.

Note that apparently using a variable names "var" causes problems with