### PR TITLE
Add a pre-report hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Added
 
+- Added a `pre-report` hook. This allows plugins to inspect and change test
+  events just before they are passed to the reporter.
+
 ## Fixed
 
 ## Changed

--- a/doc/08_extending.md
+++ b/doc/08_extending.md
@@ -170,7 +170,11 @@ first argument (possibly updated).
 
   ;; Allows "wrapping" the run function
   (wrap-run [run test-plan]
-    run))
+    run)
+
+  ;; Runs before the reporter
+  (pre-report [event]
+    event))
 ```
 
 ### Test types

--- a/doc/plugins/hooks_plugin.md
+++ b/doc/plugins/hooks_plugin.md
@@ -6,7 +6,7 @@ The hooks plugin allows hooking into Kaocha's process with arbitrary
 
   See the documentation for extending Kaocha for a description of the different
   hooks. The supported hooks are: pre-load, post-load, pre-run, post-run,
-  pre-test, post-test.
+  pre-test, post-test, pre-report.
 
 ## Implementing a hook
 

--- a/src/kaocha/plugin.clj
+++ b/src/kaocha/plugin.clj
@@ -74,3 +74,4 @@
 ;; :pre-run
 ;; :post-run
 ;; :wrap-run
+;; :pre-report

--- a/src/kaocha/plugin/hooks.clj
+++ b/src/kaocha/plugin/hooks.clj
@@ -29,7 +29,8 @@
         (update? :kaocha.hooks/pre-run load-hooks)
         (update? :kaocha.hooks/post-run load-hooks)
         (update? :kaocha.hooks/pre-test load-hooks)
-        (update? :kaocha.hooks/post-test load-hooks)))
+        (update? :kaocha.hooks/post-test load-hooks)
+        (update? :kaocha.hooks/pre-report load-hooks)))
 
   (pre-load [config]
     (reduce #(%2 %1) config (:kaocha.hooks/pre-load config)))
@@ -47,4 +48,7 @@
     (reduce #(%2 %1 test-plan) testable (:kaocha.hooks/pre-test test-plan)))
 
   (post-test [testable test-plan]
-    (reduce #(%2 %1 test-plan) testable (:kaocha.hooks/post-test test-plan))))
+    (reduce #(%2 %1 test-plan) testable (:kaocha.hooks/post-test test-plan)))
+
+  (pre-report [test-plan]
+    (reduce #(%2 %1) test-plan (:kaocha.hooks/pre-report test-plan))))

--- a/test/features/plugins/hooks_plugin.feature
+++ b/test/features/plugins/hooks_plugin.feature
@@ -6,7 +6,7 @@ Feature: Hooks plugin
 
   See the documentation for extending Kaocha for a description of the different
   hooks. The supported hooks are: pre-load, post-load, pre-run, post-run,
-  pre-test, post-test.
+  pre-test, post-test, pre-report.
 
   Scenario: Implementing a hook
     Given a file named "tests.edn" with:

--- a/test/unit/kaocha/monkey_patch_test.clj
+++ b/test/unit/kaocha/monkey_patch_test.clj
@@ -1,0 +1,13 @@
+(ns kaocha.monkey-patch-test
+  (:require [clojure.test :refer :all]
+            [kaocha.monkey-patch :as monkey-patch]
+            [kaocha.plugin :as plugin]))
+
+;; Note: this test is doing some somersaults to avoid crashing into clojure.test
+;; while it is itself running.
+(deftest pre-report-hook-is-used
+  (let [result (atom nil)]
+    (binding [plugin/*current-chain* [{:kaocha.hooks/pre-report (fn [event] (assoc event :been-here true))}]]
+      (with-redefs [monkey-patch/report (fn [event] (reset! result event))]
+        (monkey-patch/do-report {:type :pass})))
+    (is (:been-here @result))))


### PR DESCRIPTION
This allows plugins to inspect and change test results just before they are
passed to the reporter.

Notes: 

- I had to do some wrangling to get the tests to run at all, ref the changes in monkey-patch.
- I am a little unsure of my change in `src/kaocha/plugin/hooks.clj` - I'm not sure if the hooks will be on the results.
- In the documentation I called the parameter into pre-report `results` - Is that a good name?
