### PR TITLE
Provide a more descriptive message when plugin loading fails

### DIFF
--- a/src/kaocha/plugin.clj
+++ b/src/kaocha/plugin.clj
@@ -1,6 +1,7 @@
 (ns kaocha.plugin
   (:require [kaocha.output :as output]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [slingshot.slingshot :refer [try+ throw+]]))
 
 (def ^:dynamic *current-chain* [])
 
@@ -23,6 +24,10 @@
 
 (defmulti -register "Add your plugin to the stack"
   (fn [name plugins] name))
+
+(defmethod -register :default [name plugins]
+  (output/error "Couldn't load plugin " name)
+  (throw+ {:kaocha/early-exit 254} nil (str "Couldn't load plugin " name)))
 
 (defn register [name plugins]
   (try-load-third-party-lib name)

--- a/test/unit/kaocha/plugin_test.clj
+++ b/test/unit/kaocha/plugin_test.clj
@@ -1,0 +1,18 @@
+(ns kaocha.plugin-test
+  (:require [kaocha.plugin :as plugin]
+            [clojure.test :refer :all]
+            [kaocha.test-util :as util]
+            [kaocha.output :as output])
+  (:import (clojure.lang ExceptionInfo)))
+
+(deftest missing-plugin-test
+  (is (thrown-with-msg? ExceptionInfo
+                        #"Couldn't load plugin :kaocha.missing.plugin/gone"
+                        (plugin/load-all [:kaocha.missing.plugin/gone])))
+  (is (= {:err "ERROR: Couldn't load plugin :kaocha.missing.plugin/gone\n" :out "" :result nil}
+         (binding [output/*colored-output* false]
+           (util/with-out-err
+             (try
+               (plugin/load-all [:kaocha.missing.plugin/gone])
+               (catch ExceptionInfo e
+                 nil)))))))


### PR DESCRIPTION
This is an initial spike at this, but there are a number of areas for improvement:

* Do you want to fail cleanly with a colourful log instead of just throwing an exception and dying? The output is pretty gross from throwing an exception, and probably not that helpful.
* Should we try and provide more descriptive error messages around `try-load-third-party-lib` as well, instead of just falling through to the :default case?
* Is the :default keyword for the multimethod ok in this context given that plugins register as keywords?
* Should this be an error case that prevents running the tests, or just prints a warning and continues? Sometimes it's better to throw an error early, rather than print a warning that can be missed and have the tests blow up in a more spectacular manner later on.
* Do you want to try and load all of the plugins and then throw an error which describes all of the missing plugins in one shot? This seems like it makes it more complicated for limited benefit.

Currently it will print

```console
$ bin/kaocha
Exception in thread "main" clojure.lang.ExceptionInfo: Couldn't load plugin :kaocha.plugin/missing {:name :kaocha.plugin/missing}
        at kaocha.plugin$eval1067$fn__1068.invoke(plugin.clj:27)
        at clojure.lang.MultiFn.invoke(MultiFn.java:234)
        at kaocha.plugin$register.invokeStatic(plugin.clj:32)
        at kaocha.plugin$register.invoke(plugin.clj:30)
        at kaocha.plugin$load_all$fn__1074.invoke(plugin.clj:35)
        at clojure.core.protocols$fn__8144.invokeStatic(protocols.clj:168)
        at clojure.core.protocols$fn__8144.invoke(protocols.clj:124)
        at clojure.core.protocols$fn__8099$G__8094__8108.invoke(protocols.clj:19)
        at clojure.core.protocols$seq_reduce.invokeStatic(protocols.clj:31)
        at clojure.core.protocols$fn__8131.invokeStatic(protocols.clj:75)
        at clojure.core.protocols$fn__8131.invoke(protocols.clj:75)
        at clojure.core.protocols$fn__8073$G__8068__8086.invoke(protocols.clj:13)
        at clojure.core$reduce.invokeStatic(core.clj:6828)
        at clojure.core$reduce.invoke(core.clj:6810)
        at kaocha.plugin$load_all.invokeStatic(plugin.clj:35)
        at kaocha.plugin$load_all.invoke(plugin.clj:34)
        at kaocha.runner$_main_STAR_.invokeStatic(runner.clj:127)
        at kaocha.runner$_main_STAR_.doInvoke(runner.clj:121)
        at clojure.lang.RestFn.applyTo(RestFn.java:137)
        at clojure.core$apply.invokeStatic(core.clj:665)
        at clojure.core$apply.invoke(core.clj:660)
        at kaocha.runner$_main.invokeStatic(runner.clj:146)
        at kaocha.runner$_main.doInvoke(runner.clj:144)
        at clojure.lang.RestFn.applyTo(RestFn.java:137)
        at clojure.lang.Var.applyTo(Var.java:705)
        at clojure.core$apply.invokeStatic(core.clj:665)
        at clojure.main$main_opt.invokeStatic(main.clj:491)
        at clojure.main$main_opt.invoke(main.clj:487)
        at clojure.main$main.invokeStatic(main.clj:598)
        at clojure.main$main.doInvoke(main.clj:561)
        at clojure.lang.RestFn.applyTo(RestFn.java:137)
        at clojure.lang.Var.applyTo(Var.java:705)
        at clojure.main.main(main.java:37)
```

Fixes #35