### PR TITLE
Remove dependency on clojure.java-time

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,6 @@
   lambdaisland/deep-diff       {:mvn/version "0.0-25"}
   org.tcrawley/dynapath        {:mvn/version "1.0.0"}
   slingshot                    {:mvn/version "0.12.2"}
-  clojure.java-time            {:mvn/version "0.3.2"}
   hawk                         {:mvn/version "0.2.11"}
   expound                      {:mvn/version "0.7.2"}
   orchestra                    {:mvn/version "2018.12.06-2"}

--- a/pom.xml
+++ b/pom.xml
@@ -71,11 +71,6 @@
       <version>0.1.2</version>
     </dependency>
     <dependency>
-      <groupId>clojure.java-time</groupId>
-      <artifactId>clojure.java-time</artifactId>
-      <version>0.3.2</version>
-    </dependency>
-    <dependency>
       <groupId>orchestra</groupId>
       <artifactId>orchestra</artifactId>
       <version>2018.12.06-2</version>

--- a/src/kaocha/plugin/profiling.clj
+++ b/src/kaocha/plugin/profiling.clj
@@ -1,10 +1,10 @@
 (ns kaocha.plugin.profiling
-  (:require [kaocha.plugin :as plugin :refer [defplugin]]
-            [java-time :as jt]
-            [kaocha.testable :as testable]
+  (:require [clojure.java.io :as io]
             [clojure.string :as str]
-            [clojure.java.io :as io])
-  (:import java.time.Instant))
+            [kaocha.plugin :as plugin :refer [defplugin]]
+            [kaocha.testable :as testable])
+  (:import java.time.Instant
+           java.time.temporal.ChronoUnit))
 
 (defn start [testable]
   (assoc testable ::start (Instant/now)))
@@ -12,9 +12,9 @@
 (defn stop [testable]
   (cond-> testable
     (::start testable)
-    (assoc ::duration (jt/time-between (::start testable)
-                                       (Instant/now)
-                                       :nanos))))
+    (assoc ::duration (.until (::start testable)
+                              (Instant/now)
+                              ChronoUnit/NANOS))))
 
 (defplugin kaocha.plugin/profiling
   (pre-run [test-plan]


### PR DESCRIPTION
It seems to be used for only one function that is just as easily implemented
using java.time directly.

I noticed this because I got an error when trying to evaluate kaocha in the repl. It had something to do with clojure.java-time. Since it was so easy to remove, I didn't spend much time figuring out why it failed.