### PR TITLE
Run all tests when --focus-meta doesn't match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 - Added a `pre-report` hook. This allows plugins to inspect and change test
   events just before they are passed to the reporter.
-- Added a `:kaocha.plugin/notifier` plugin that pops up desktop notifications when a test run passes or fails.
+- Added a `:kaocha.plugin/notifier` plugin that pops up desktop notifications
+  when a test run passes or fails.
+- Ignore `--focus-meta` when none of the tests have this particular metadata.
 
 ## Fixed
 

--- a/doc/06_focusing_and_skipping.md
+++ b/doc/06_focusing_and_skipping.md
@@ -61,8 +61,31 @@ work. You can mark these with a metadata tag:
 To ignore such tests, add a `:skip-meta` key to the test suite config:
 
 ``` clojure
-#kaocha/v1 {:tests [{:id :unit
-                  :skip-meta [:pending]}]}
+#kaocha/v1
+{:tests [{:id :unit
+          :skip-meta [:pending]}]}
 ```
 
-This also works for metadata placed on the test's namespace.
+This also works for metadata placed on the test's namespace, or any other
+metadata that a given test type implementation exposes. For example
+kaocha-cucumber converts scenario tags into metadata.
+
+### Focusing on metadata: special case
+
+`--focus-meta` will only work if at least one test has this metadata tag. If not
+a single test matches then this metadata is ignored. Assuming no other filters
+are in effect this will result in running all tests.
+
+This way you can configure a certain key in `tests.edn` that you can use when
+you want to zone in on a specific test. Add the metadata to the test and only
+this test runs, remove it and the whole suite runs.
+
+``` clojure
+#kaocha/v1
+{:tests [{:focus-meta [:xxx]}]}
+```
+
+```clojure
+(deftest ^:xxx my-test
+  ,,,)
+```

--- a/src/kaocha/core_ext.clj
+++ b/src/kaocha/core_ext.clj
@@ -1,5 +1,6 @@
 (ns kaocha.core-ext
   "Core language extensions"
+  (:refer-clojure :exclude [symbol])
   (:import [java.util.regex Pattern]))
 
 (defn regex? [x]
@@ -33,3 +34,19 @@
   arguments to a map."
   [f & args]
   (apply f (apply concat (butlast args) (last args))))
+
+(defn symbol
+  "Backport from Clojure 1.10, symbol function that's a bit more lenient on its
+  inputs.
+
+  Returns a Symbol with the given namespace and name. Arity-1 works on strings,
+  keywords, and vars."
+  ^clojure.lang.Symbol
+  ([name]
+   (cond
+     (symbol? name) name
+     (instance? String name) (clojure.lang.Symbol/intern name)
+     (instance? clojure.lang.Var name) (.toSymbol ^clojure.lang.Var name)
+     (instance? clojure.lang.Keyword name) (.sym ^clojure.lang.Keyword name)
+     :else (throw (IllegalArgumentException. "no conversion to symbol"))))
+  ([ns name] (clojure.lang.Symbol/intern ns name)))

--- a/src/kaocha/load.clj
+++ b/src/kaocha/load.clj
@@ -1,4 +1,5 @@
 (ns kaocha.load
+  (:refer-clojure :exclude [symbol])
   (:require [kaocha.core-ext :refer :all]
             [kaocha.classpath :as classpath]
             [kaocha.testable :as testable]

--- a/src/kaocha/monkey_patch.clj
+++ b/src/kaocha/monkey_patch.clj
@@ -1,4 +1,5 @@
 (ns kaocha.monkey-patch
+  (:refer-clojure :exclude [symbol])
   (:require [clojure.string :as str]
             [clojure.test :as t]
             [kaocha.core-ext :refer :all]

--- a/src/kaocha/report.clj
+++ b/src/kaocha/report.clj
@@ -88,6 +88,7 @@
   ``` clojure
   (kaocha.hierarchy/derive! :mismatch :kaocha/fail-type)
   ```"
+  (:refer-clojure :exclude [symbol])
   (:require [kaocha.core-ext :refer :all]
             [kaocha.output :as output]
             [kaocha.plugin.capture-output :as capture]

--- a/src/kaocha/type/clojure/test.clj
+++ b/src/kaocha/type/clojure/test.clj
@@ -1,4 +1,5 @@
 (ns kaocha.type.clojure.test
+  (:refer-clojure :exclude [symbol])
   (:require [kaocha.core-ext :refer :all]
             [clojure.spec.alpha :as s]
             [kaocha.type.ns :as type.ns]

--- a/src/kaocha/type/ns.clj
+++ b/src/kaocha/type/ns.clj
@@ -1,4 +1,5 @@
 (ns kaocha.type.ns
+  (:refer-clojure :exclude [symbol])
   (:require [clojure.test :as t]
             [kaocha.core-ext :refer :all]
             [kaocha.testable :as testable]

--- a/src/kaocha/watch.clj
+++ b/src/kaocha/watch.clj
@@ -1,4 +1,5 @@
 (ns kaocha.watch
+  (:refer-clojure :exclude [symbol])
   (:require [hawk.core :as hawk]
             [kaocha.api :as api]
             [kaocha.result :as result]

--- a/test/shared/kaocha/test_helper.clj
+++ b/test/shared/kaocha/test_helper.clj
@@ -1,4 +1,5 @@
 (ns kaocha.test-helper
+  (:refer-clojure :exclude [symbol])
   (:require [clojure.test :as t]
             [kaocha.core-ext :refer :all]
             [matcher-combinators.result :as mc.result]

--- a/test/unit/kaocha/core_ext_test.clj
+++ b/test/unit/kaocha/core_ext_test.clj
@@ -1,4 +1,5 @@
 (ns kaocha.core-ext-test
+  (:refer-clojure :exclude [symbol])
   (:require [clojure.test :refer :all]
             [kaocha.core-ext :refer :all]))
 

--- a/test/unit/kaocha/plugin/filter_test.clj
+++ b/test/unit/kaocha/plugin/filter_test.clj
@@ -1,54 +1,100 @@
 (ns kaocha.plugin.filter-test
-  (:require [clojure.test :refer :all]
-            [kaocha.plugin.filter :as filter]))
-
+  (:require [clojure.test :refer [is]]
+            [kaocha.test :refer [deftest]]
+            [kaocha.plugin.filter :as f]
+            [kaocha.testable :as testable]))
 
 (deftest matches?-test
-  (is (filter/matches? {:kaocha.testable/id :foo.bar/baz}
-                       '[foo.bar/baz] []))
+  (is (f/matches? {:kaocha.testable/id :foo.bar/baz}
+                  '[foo.bar/baz]
+                  []))
 
-  (is (filter/matches? {:kaocha.testable/id :foo.bar/baz}
-                       '[foo.bar] []))
+  (is (f/matches? {:kaocha.testable/id :foo.bar/baz}
+                  '[foo.bar]
+                  []))
 
-  (is (filter/matches? {:kaocha.testable/meta {:foo.bar/baz true}}
-                       [] '[foo.bar/baz]))
+  (is (f/matches? {:kaocha.testable/meta {:foo.bar/baz true}}
+                  []
+                  '[foo.bar/baz]))
 
-  (is (filter/matches? {:kaocha.testable/id :foo.bar}
-                       '[foo.bar] [])))
+  (is (f/matches? {:kaocha.testable/id :foo.bar}
+                  '[foo.bar]
+                  [])))
+
+(deftest filters-test
+  (is (= '{:skip [skip]
+           :focus [focus]
+           :skip-meta [:skip-meta]
+           :focus-meta [:focus-meta]}
+         (f/filters '#:kaocha.filter{:skip [skip]
+                                     :focus [focus]
+                                     :skip-meta [:skip-meta]
+                                     :focus-meta [:focus-meta]}))))
+
+(deftest merge-filters-test
+  (is (= {:skip () :skip-meta () :focus nil :focus-meta nil}
+         (f/merge-filters {} {})))
+
+  (is (= {:skip '[foo bar] :skip-meta () :focus nil :focus-meta nil}
+         (f/merge-filters
+          {:skip '[foo]}
+          {:skip '[bar]})))
+
+  (is (= {:skip () :skip-meta () :focus '[bar] :focus-meta nil}
+         (f/merge-filters
+          {:focus '[foo]}
+          {:focus '[bar]})))
+
+  (is (= {:skip () :skip-meta () :focus '[foo] :focus-meta nil}
+         (f/merge-filters
+          {:focus '[foo]}
+          {:focud '[]}))))
+
+(deftest truthy-keys-test
+  (is (= [:zzz]
+         (f/truthy-keys {:xxx false
+                         :yyy nil
+                         :zzz true}))))
+
+(deftest remove-missing-metadata-keys-test
+  (is (= #{:xxx}
+         (f/remove-missing-metadata-keys
+          [:xxx :yyy]
+          {:kaocha.test-plan/tests [{:kaocha.testable/meta {:xxx true}}]}))))
 
 (deftest filter-testable-test
-  (is (= (filter/filter-testable {:kaocha.testable/id :foo.bar/baz}
-                                 {:skip '[foo.bar]})
+  (is (= (f/filter-testable {:kaocha.testable/id :foo.bar/baz}
+                            {:skip '[foo.bar]})
          #:kaocha.testable{:id :foo.bar/baz, :skip true}))
 
-  (is (= (filter/filter-testable {:kaocha.testable/id :x/_1
-                                  :kaocha.test-plan/tests [{:kaocha.testable/id :y/_1}]}
-                                 {:skip '[y/_1]})
+  (is (= (f/filter-testable {:kaocha.testable/id :x/_1
+                             :kaocha.test-plan/tests [{:kaocha.testable/id :y/_1}]}
+                            {:skip '[y/_1]})
          {:kaocha.testable/id :x/_1
           :kaocha.test-plan/tests [#:kaocha.testable{:id :y/_1, :skip true}]}))
 
-  (is (= (filter/filter-testable {:kaocha.testable/id :x/_1
-                                  :kaocha.test-plan/tests [{:kaocha.testable/id :y/_1}]}
-                                 {:focus '[x/_1]})
+  (is (= (f/filter-testable {:kaocha.testable/id :x/_1
+                             :kaocha.test-plan/tests [{:kaocha.testable/id :y/_1}]}
+                            {:focus '[x/_1]})
          {:kaocha.testable/id :x/_1, :kaocha.test-plan/tests [#:kaocha.testable{:id :y/_1}]}))
 
-  (is (= (filter/filter-testable {:kaocha.testable/id :x/_1
-                                  :kaocha.test-plan/tests [{:kaocha.testable/id :y/_1}
-                                                           {:kaocha.testable/id :z/_1}]}
-                                 {:focus '[z/_1]})
+  (is (= (f/filter-testable {:kaocha.testable/id :x/_1
+                             :kaocha.test-plan/tests [{:kaocha.testable/id :y/_1}
+                                                      {:kaocha.testable/id :z/_1}]}
+                            {:focus '[z/_1]})
 
          {:kaocha.testable/id :x/_1,
           :kaocha.test-plan/tests [#:kaocha.testable{:id :y/_1
                                                      :skip true}
                                    #:kaocha.testable{:id :z/_1}]}))
 
-  (is (= (filter/filter-testable {:kaocha.testable/id :x/_1
-                                  :kaocha.test-plan/tests       [{:kaocha.testable/id :y/_1}
-                                                                 {:kaocha.testable/id :y/_2
-                                                                  :kaocha.test-plan/tests
-                                                                  [{:kaocha.testable/id :z/_1}
-                                                                   {:kaocha.testable/id :z/_2}]}]}
-                                 {:focus '[y/_2] :skip '[z/_1]})
+  (is (= (f/filter-testable {:kaocha.testable/id :x/_1
+                             :kaocha.test-plan/tests       [{:kaocha.testable/id :y/_1}
+                                                            {:kaocha.testable/id :y/_2
+                                                             :kaocha.test-plan/tests
+                                                             [{:kaocha.testable/id :z/_1}
+                                                              {:kaocha.testable/id :z/_2}]}]}
+                            {:focus '[y/_2] :skip '[z/_1]})
          {:kaocha.testable/id :x/_1
           :kaocha.test-plan/tests       [{:kaocha.testable/id   :y/_1
                                           :kaocha.testable/skip true}
@@ -58,23 +104,23 @@
                                             :kaocha.testable/skip true}
                                            {:kaocha.testable/id :z/_2}]}]}))
 
-  (is (= (filter/filter-testable {:kaocha.testable/id     :x
-                                  :kaocha.test-plan/tests [{:kaocha.testable/id :y
-                                                            :kaocha.test-plan/tests
-                                                            [{:kaocha.testable/id :z}
-                                                             {:kaocha.testable/id :z/_2}]}]}
-                                 {:focus '[z]})
+  (is (= (f/filter-testable {:kaocha.testable/id     :x
+                             :kaocha.test-plan/tests [{:kaocha.testable/id :y
+                                                       :kaocha.test-plan/tests
+                                                       [{:kaocha.testable/id :z}
+                                                        {:kaocha.testable/id :z/_2}]}]}
+                            {:focus '[z]})
          {:kaocha.testable/id :x,
           :kaocha.test-plan/tests [{:kaocha.testable/id :y,
                                     :kaocha.test-plan/tests [#:kaocha.testable{:id :z}
                                                              #:kaocha.testable{:id :z/_2}]}]}))
-  (is (= (filter/filter-testable {:kaocha.testable/id     :x
-                                  :kaocha.filter/focus    [:z/_2]
-                                  :kaocha.test-plan/tests [{:kaocha.testable/id :y
-                                                            :kaocha.test-plan/tests
-                                                            [{:kaocha.testable/id :z}
-                                                             {:kaocha.testable/id :z/_2}]}]}
-                                 {})
+  (is (= (f/filter-testable {:kaocha.testable/id     :x
+                             :kaocha.filter/focus    [:z/_2]
+                             :kaocha.test-plan/tests [{:kaocha.testable/id :y
+                                                       :kaocha.test-plan/tests
+                                                       [{:kaocha.testable/id :z}
+                                                        {:kaocha.testable/id :z/_2}]}]}
+                            {})
          {:kaocha.testable/id :x,
           :kaocha.filter/focus [:z/_2],
           :kaocha.test-plan/tests

--- a/test/unit/kaocha/type/clojure/test_test.clj
+++ b/test/unit/kaocha/type/clojure/test_test.clj
@@ -1,4 +1,5 @@
 (ns kaocha.type.clojure.test-test
+  (:refer-clojure :exclude [symbol])
   (:require [clojure.test :refer :all]
             [kaocha.core-ext :refer :all]
             [kaocha.testable :as testable]

--- a/test/unit/kaocha/type/ns_test.clj
+++ b/test/unit/kaocha/type/ns_test.clj
@@ -1,4 +1,5 @@
 (ns kaocha.type.ns-test
+  (:refer-clojure :exclude [symbol])
   (:require [clojure.test :as t :refer :all]
             [kaocha.core-ext :refer :all]
             [kaocha.testable :as testable]

--- a/test/unit/kaocha/type/var_test.clj
+++ b/test/unit/kaocha/type/var_test.clj
@@ -1,4 +1,5 @@
 (ns kaocha.type.var-test
+  (:refer-clojure :exclude [symbol])
   (:require [clojure.test :as t :refer :all]
             [kaocha.test-factories :as f]
             [kaocha.testable :as testable]


### PR DESCRIPTION
Ignore :focus-meta tags that don't match any tests. Print a warning.

@magnars I know you would prefer not to have the warnings, but I'll open a separate ticket for making the warnings configurable.

Closes #40 
