### PR TITLE
Add the wrap-run hook to the hooks plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@
 - Added a `:kaocha.plugin/notifier` plugin that pops up desktop notifications
   when a test run passes or fails.
 - Ignore `--focus-meta` when none of the tests have this particular metadata.
+- Print a nicer message when a plugin can't be loaded (Daniel Compton)
+- Add the `wrap-run` hook to the hooks plugin.
 
 ## Fixed
+
+- Preserve changes to the config made in a `pre-load` hook
 
 ## Changed
 

--- a/src/kaocha/api.clj
+++ b/src/kaocha/api.clj
@@ -32,7 +32,8 @@
          (.removeShutdownHook runtime# on-shutdown#)))))
 
 (defn test-plan [config]
-  (let [tests (:kaocha/tests (plugin/run-hook :kaocha.hooks/pre-load config))]
+  (let [config (plugin/run-hook :kaocha.hooks/pre-load config)
+        tests (:kaocha/tests config)]
     (plugin/run-hook
      :kaocha.hooks/post-load
      (-> config

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -95,13 +95,16 @@
 
 (defn apply-cli-args [config args]
   (if (seq args)
-    (update config
-            :kaocha/tests
-            (fn [tests]
-              (mapv #(if (contains? (set args) (:kaocha.testable/id %))
-                       %
-                       (assoc % :kaocha.testable/skip true))
-                    tests)))
+    (-> config
+        (assoc :kaocha/cli-args args)
+        (update :kaocha/tests
+                (fn [tests]
+                  (let [run-suite? (set args)]
+                    (mapv (fn [{suite-id :kaocha.testable/id :as suite}]
+                            (cond-> suite
+                              (not (run-suite? suite-id))
+                              (assoc :kaocha.testable/skip true)))
+                          tests)))))
     config))
 
 (defn resolve-reporter [reporter]

--- a/src/kaocha/core_ext.clj
+++ b/src/kaocha/core_ext.clj
@@ -18,6 +18,12 @@
 (defn ns? [x]
   (instance? clojure.lang.Namespace x))
 
+(defn file? [x]
+  (instance? java.io.File x))
+
+(defn path? [x]
+  (instance? java.nio.file.Path x))
+
 (defn regex
   ([x & xs]
    (regex (apply str x xs)))

--- a/src/kaocha/plugin.clj
+++ b/src/kaocha/plugin.clj
@@ -87,4 +87,6 @@
 ;; :pre-run
 ;; :post-run
 ;; :wrap-run
+;; :pre-test
+;; :post-test
 ;; :pre-report

--- a/src/kaocha/plugin/hooks.clj
+++ b/src/kaocha/plugin/hooks.clj
@@ -30,6 +30,7 @@
         (update? :kaocha.hooks/post-load load-hooks)
         (update? :kaocha.hooks/pre-run load-hooks)
         (update? :kaocha.hooks/post-run load-hooks)
+        (update? :kaocha.hooks/wrap-run load-hooks)
         (update? :kaocha.hooks/pre-test load-hooks)
         (update? :kaocha.hooks/post-test load-hooks)
         (update? :kaocha.hooks/pre-report load-hooks)))
@@ -45,6 +46,9 @@
 
   (post-run [test-plan]
     (reduce #(%2 %1) test-plan (:kaocha.hooks/post-run test-plan)))
+
+  (wrap-run [run test-plan]
+    (reduce #(%2 %1) run (:kaocha.hooks/wrap-run test-plan)))
 
   (pre-test [testable test-plan]
     (reduce #(%2 %1 test-plan) testable (:kaocha.hooks/pre-test test-plan)))

--- a/src/kaocha/test.clj
+++ b/src/kaocha/test.clj
@@ -11,10 +11,25 @@
             [kaocha.testable :as testable]
             [kaocha.api :as api]))
 
-(defmacro deftest [name & body]
+(defmacro deftest
+  {:doc (:doc (meta #'clojure.test/deftest))
+   :arglists (:arglists (meta #'clojure.test/deftest))}
+  [name & body]
   (if kaocha.api/*active?*
     `(clojure.test/deftest ~name ~@body)
     `(do
        (let [var# (clojure.test/deftest ~name ~@body)]
          (or (find-ns 'kaocha.repl) (require 'kaocha.repl))
          ((find-var 'kaocha.repl/run) var#)))))
+
+(defmacro is
+  {:doc (:doc (meta #'clojure.test/is))
+   :arglists (:arglists (meta #'clojure.test/is))}
+  [& args]
+  `(clojure.test/is ~@args))
+
+(defmacro testing
+  {:doc (:doc (meta #'clojure.test/testing))
+   :arglists (:arglists (meta #'clojure.test/testing))}
+  [& args]
+  `(clojure.test/testing ~@args))

--- a/test/unit/kaocha/config_test.clj
+++ b/test/unit/kaocha/config_test.clj
@@ -1,5 +1,5 @@
 (ns kaocha.config-test
-  (:require [clojure.test :refer :all]
+  (:require [kaocha.test :refer :all]
             [kaocha.config :as c]))
 
 (def rename-key @#'c/rename-key)
@@ -104,10 +104,15 @@
 (deftest apply-cli-args-test
   (is (= {:kaocha/tests
           [{:kaocha.testable/id :foo, :kaocha.testable/skip true}
-           {:kaocha.testable/id :bar}]}
+           {:kaocha.testable/id :bar}]
+          :kaocha/cli-args [:bar]}
          (c/apply-cli-args {:kaocha/tests [{:kaocha.testable/id :foo}
                                            {:kaocha.testable/id :bar}]}
-                           [:bar]))))
+                           [:bar])))
+
+  (is (= {:kaocha/tests [{:kaocha.testable/id :foo}]}
+         (c/apply-cli-args {:kaocha/tests [{:kaocha.testable/id :foo}]}
+                           []))))
 
 (defn rep1 [m] (println "rep1 called"))
 (defn rep2 [m] (println "rep2 called"))

--- a/test/unit/kaocha/plugin/hooks_test.clj
+++ b/test/unit/kaocha/plugin/hooks_test.clj
@@ -1,10 +1,25 @@
 (ns kaocha.plugin.hooks-test
-  (:require [clojure.test :refer :all]
+  (:require [kaocha.test :refer :all]
             [kaocha.plugin.hooks :as hooks]
             [kaocha.testable :as testable]
             [kaocha.test-util :as util]
             [kaocha.plugin :as plugin]
             [clojure.test :as t]))
+
+(def ^:dynamic *inside-wrap-run?* false)
+
+(deftest wrap-run-test
+  (let [run       (fn []
+                    (print "inside-wrap-run?:" *inside-wrap-run?*))
+        wrap-run  (fn [run]
+                    (fn [& args]
+                      (binding [*inside-wrap-run?* true]
+                        (apply run args))))
+        test-plan {:kaocha.hooks/wrap-run [wrap-run]}]
+    (binding [plugin/*current-chain* [hooks/hooks-hooks]]
+      (let [run' (plugin/run-hook :kaocha.hooks/wrap-run run test-plan)]
+        (is (= "inside-wrap-run?: true"
+               (with-out-str (run'))))))))
 
 (deftest pre-report-test
   (is (match? {:report [{:type :fail


### PR DESCRIPTION
This is a useful hook e.g. for setting dynamic bindings.

``` clojure
(defplugin my.ns/my-plugin
  (wrap-run [run test-plan]
    (fn [& args]
      (binding [...]
        (apply run args)))))
```