### PR TITLE
Make the notifier plugin more concise

### DIFF
--- a/src/kaocha/plugin/notifier.clj
+++ b/src/kaocha/plugin/notifier.clj
@@ -25,13 +25,14 @@
 
 (defn message [result]
   (let [{::result/keys [count pass fail error pending]} (result/testable-totals result)]
-    (str count " tests, "
-         (+ pass fail error) " assertions, "
+    (str count " tests"
          (when (pos-int? error)
-           (str error " errors, "))
+           (str ", " error " errors"))
          (when (pos-int? pending)
-           (str pending " pending, "))
-         fail " failures.")))
+           (str ", "pending " pending"))
+         (when (pos-int? fail)
+           (str ", " fail " failures"))
+         ".")))
 
 (defn title [result]
   (if (result/failed? result)

--- a/test/features/plugins/notifier_plugin.feature
+++ b/test/features/plugins/notifier_plugin.feature
@@ -62,7 +62,7 @@ Feature: Desktop Notifications
     Then the output should contain:
     """
     ⛔️ Failing
-    1 tests, 1 assertions, 1 failures.
+    1 tests, 1 failures.
     true
     1
     critical

--- a/test/unit/kaocha/plugin/notifier_test.clj
+++ b/test/unit/kaocha/plugin/notifier_test.clj
@@ -20,7 +20,7 @@
     (is (str/starts-with? (n/detect-command) "terminal-notifier"))))
 
 (deftest message-test
-  (is (= "3 tests, 7 assertions, 4 errors, 5 pending, 1 failures."
+  (is (= "3 tests, 4 errors, 5 pending, 1 failures."
          (n/message
           {:kaocha.result/tests [{:kaocha.testable/id :foo
                                   :kaocha.testable/type :foo/bar


### PR DESCRIPTION
Given the limited screen real estate notifications shouldn't be too chatty: drop
the number of assertions, and only print error/failure counts when non-zero.