### PR TITLE
A boatload of improvements to --watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@
 - Added a `:kaocha.plugin/notifier` plugin that pops up desktop notifications
   when a test run passes or fails.
 - Add the `wrap-run` hook to the hooks plugin.
+- Watch mode: re-run all tests by pressing "enter"
+- Watch mode: watch `tests.edn` for changes
+- Watch mode: ignore certain files with `:kaocha.watch/ignore [".*" ,,,]`
 
 ## Fixed
 
 - Preserve changes to the config made in a `pre-load` hook
+- Watch mode: if a namespace fails to load then report it clearly and fail the
+  test run, skipping any remaining tests.
 
 ## Changed
 

--- a/bin/generate_toc
+++ b/bin/generate_toc
@@ -4,7 +4,7 @@ def uslug(s)
   s.downcase.gsub(/[^\p{L}\p{N}]+/, ' ').gsub(/[\p{Z}\s]+/, '-')
 end
 
-Dir['doc/*.md'].sort.each do |f|
+Dir['doc/**/*.md'].sort.each do |f|
   title = File.read(f).each_line.first.sub(/^#+/, '').strip
   puts "- [%s](https://cljdoc.org/d/lambdaisland/kaocha/CURRENT/doc/%s)" % [title, uslug(title)]
 end

--- a/doc/01_introduction.md
+++ b/doc/01_introduction.md
@@ -1,18 +1,16 @@
 ## 1. Introduction
 
-> I test, therefore I am. — René Descartes
+> Quality is not an act, it is a habit. — Aristotle
 
-Kaocha is a _test runner_, its core task is to load tests and execute them,
-reporting on their progress and final result.
+Kaocha is an all-in-one testing tool, its core task is to load tests and execute
+them, reporting on their progress and final result. It does this in a way that
+encourages good habits, supports multiple workflow styles, and optimizes for
+ergonomics.
 
-It provides a uniform way for projects to define their test setup: the different
-test suites they have, the testing libraries they use, the output reporting they
-prefer. This way developers can jump into a new project and instantly be up to
-speed.
-
-Kaocha understands different types of tests: `clojure.test`, Midje, in the
-future even ClojureScript, so that all of a project's tests can be handled in
-the same way.
+Kaocha has a modular architecture. It understands different types of tests:
+`clojure.test`, ClojureScript, Cucumber, Fudje, Expectations, so that all of a
+project's tests can be handled in the same way, and so that more can be added
+without requiring changes to the core.
 
 It aims to deliver all the features a developer might expect from their test
 tooling. Different people have different workflows, different styles of writing
@@ -20,11 +18,6 @@ and running tests. We want to make sure we got you covered.
 
 Much of this is achieved through plugins. This way the Kaocha core can remain
 focused, while making it easy to experiment with new features.
-
-Kaocha largely sprang from the desire to bring the experience found in other
-language ecosystems to Clojure. If you came to Clojure from another language,
-and you're missing some part of the test tooling you used to have, then please
-file and issue and we'll try to sort you out.
 
 To use Kaocha you create a `tests.edn` at the root of your project, and run
 tests from the command line or from the REPL.
@@ -40,29 +33,13 @@ Features include
 - Profiling (show slowest tests)
 - Dynamic classpath handling
 - Tests as data (get test config, test plan, or test results as EDN)
-- Extensible test types (clojure.test, Midje, ...)
-- Extensible through plugins 
-- Tool agnostic (Clojure CLI, Leiningen, ...)
-
-## Current status
-
-Kaocha is a work in progress. Focus so far has been on internal APIs, and on the
-data formats for configuration, test plan, and test results. These things are
-largely stable and complete.
-
-The command line test runner is largely feature complete, and being used in the
-real world. More work is still needed to support and intergrate with other
-frameworks and tools.
-
-- [X] clojure.test support 
-- [X] Midje support
-- [-] ClojureScript support
-- [ ] Expectation support
-- [X] Clojure CLI
-- [X] Leiningen
-- [ ] Boot
-- [ ] Cloverage
+- Extensible test types (clojure.test, Cucumber, ...)
+- Extensible through plugins
+- Tool agnostic (Clojure CLI, Leiningen, boot)
 
 Currently Kaocha's versioning scheme is `0.0-${commit count}`, and releases are
 made often. As long as the version is at `0.0` Kaocha will be considered alpha,
 in other words: subject to change. Keep an eye on the CHANGELOG.
+
+Kaocha requires Clojure 1.9. ClojureScript support requires Clojure and
+ClojureScript 1.10.

--- a/doc/02_installing.md
+++ b/doc/02_installing.md
@@ -98,3 +98,7 @@ projects. The rest of the documentation assumes you can invoke Kaocha with
 
 lein kaocha "$@"
 ```
+
+### Boot
+
+See [kaocha-boot](https://github.com/lambdaisland/kaocha-boot) for instructions.

--- a/doc/03_configuration.md
+++ b/doc/03_configuration.md
@@ -103,8 +103,6 @@ This is what the `:unit` suite looks like after expansion:
 
 If you don't define any test suites than Kaocha assumes a single `:unit` test suite.
 
-
-
 ### :kaocha.type/clojure.test
 
 The main test suite type implemented at the moment is one for `clojure.test`,
@@ -142,6 +140,14 @@ or from the command line
 
 ``` shell
 bin/kaocha --plugin kaocha.plugin/profiling
+```
+
+For plugins in the `kaocha.plugin` namespace the namespace can be ommitted from
+the command line:
+
+
+``` shell
+bin/kaocha --plugin profiling
 ```
 
 Some plugins are needed for the normal functioning of Kaocha. These are added
@@ -225,6 +231,17 @@ integration:   100% [==================================================] 1/1
 19 test vars, 55 assertions, 0 failures.
 ```
 
+### `kaocha.report/tap`
+
+Reporter that outputs TAP (Test Anything Protocol). Useful for integrating with
+other tools. See also
+[kaocha-junit-xml](https://github.com/lambdaisland/kaocha-junit-xml).
+
+### `kaocha.report/debug`
+
+Prints the `clojure.test` style events map directly, with some keys like
+`:kaocha/testable` filtered out to prevent it from getting too noisy.
+
 ## Example
 
 You should be able to start with a simple `#kaocha/v1 {}`, and leave most
@@ -255,7 +272,8 @@ configuration at its default. This is merely an example of what's possible
  ;; Colorize output (use ANSI escape sequences).
  :color?      true
 
- ;; Watch the file system for changes and re-run.
+ ;; Watch the file system for changes and re-run. You can change this here to be
+ ;; on by default, then disable it when necessary with `--no-watch`.
  :watch?      false
 
  ;; Specifiy the reporter function that generates output. Must be a namespaced
@@ -264,8 +282,11 @@ configuration at its default. This is merely an example of what's possible
  ;; at a var containing a vector, then kaocha will call all referenced functions
  ;; for reporting.
  :reporter    kaocha.report/documentation
- 
- ;; Plugin specific configuration. Show the 10 slowest tests of each type, rather 
+
+ ;; Enable/disable output capturing.
+ :capture-output? true
+
+ ;; Plugin specific configuration. Show the 10 slowest tests of each type, rather
  ;; than only 3.
  :kaocha.plugin.profiling/count 10
  }}

--- a/doc/04_running_kaocha_cli.md
+++ b/doc/04_running_kaocha_cli.md
@@ -38,8 +38,15 @@ output.
 
 For example, to see a colorful progress bar, use
 
-```
+``` shell
 bin/kaocha --reporter kaocha.report.progress/progress
+```
+
+Plugins in the `kaocha.plugin` namespace, and reporters in the `kaocha.report`
+namespace can be specified without the namespace.
+
+``` shell
+bin/kaocha --plugin profiling --reporter documentation
 ```
 
 ## Fail fast mode
@@ -64,21 +71,11 @@ base with the same seed you will always get the same test order. This way you
 can e.g. reproduce a test run that failed on a build server.
 
 ``` shell
-bin/kaocha --seed 10761431 
+bin/kaocha --seed 10761431
 ```
 
 Use `--no-randomize` to load suites in the order they are specified, and vars in
-the order they occur in the source.
-
-## Watch mode
-
-The `--watch` flag will tell Kaocha to watch both the test and source files for
-changes, and automatically re-run all tests.
-
-If any tests fail, then upon the next change first the failed tests will be run.
-Only when they pass is the complete suite run again.
-
-To shorten the feedback loop you can combine `--watch` with `--fail-fast`.
+the order they occur in the source. You can disable randomization in `tests.edn`
 
 ## Control output
 
@@ -108,4 +105,3 @@ structures (EDN) with `--print-config`, `--print-test-plan`, and
 --print-test-plan                 Load tests, build up a test plan, then print out the test plan and exit.
 --print-result                    Print the test result map as returned by the Kaocha API.
 ```
-

--- a/doc/05_running_kaocha_repl.md
+++ b/doc/05_running_kaocha_repl.md
@@ -54,7 +54,7 @@ understand namespace and var objects.
 (run #'rand-ints-test)
 ```
 
-`(run)` without any arguments is equivalent to `(run *ns*)`. If you really want to run all test suites without discrimination, use [run-all](https://cljdoc.xyz/d/lambdaisland/kaocha/CURRENT/api/kaocha.repl#run-all).
+`(run)` without any arguments is equivalent to `(run *ns*)`. If you really want to run all test suites without discrimination, use [run-all](https://cljdoc.org/d/lambdaisland/kaocha/CURRENT/api/kaocha.repl#run-all).
 
 
 ## Passing configuration
@@ -87,3 +87,9 @@ redefines and runs the test in one go.
 
 When using CIDER this combines really well with
 `cider-pprint-eval-defun-at-point` (binding in CIDER 1.18.1: `C-c C-f`).
+
+## Config and Test plan
+
+The `(kaocha.repl/config)` and `(kaocha.config/test-plan)` functions are very
+useful when diagnosing issues, and can be helpful when developing plugins or
+test types.

--- a/doc/07_watch_mode.md
+++ b/doc/07_watch_mode.md
@@ -1,0 +1,70 @@
+## 7. Watch mode
+
+You can enable watch mode with the `--watch` command line flag. If you want
+watch mode to be the default you can also configure it in `tests.edn` with
+`:watch? true`. In that case the `--no-watch` flag turns it off again.
+
+When running in watch mode Kaocha will keep an eye on your test and source
+directories (as configured on the test suites), as well as your Kaocha
+configuration in `tests.edn`. Whenever any of these files changes it tries to
+reload the changed files, and then runs your tests again.
+
+Watch mode is based on `tools.namespace`, this library keeps track of the
+dependencies between namespaces. When a file changes then any namespace that
+depends on it gets unloaded first, completely erasing the namespace and its vars
+from Clojure's memory, before loading them again from scratch.
+
+This fixes a lot of issues that are present with more naive code reloading
+schemes, but it comes with its own set of caveats. Refer to the [tools.namespace
+README](https://github.com/clojure/tools.namespace) for more information.
+
+If any tests fail, then upon the next change first the failed tests will be run.
+Only when they pass is the complete suite run again.
+
+Sometimes your source or test directories will contain files that should be
+ignored by watch mode, for instance temporary files left by your editor. You can
+tell watch mode to ignore these with the `:kaocha.watch/ignore` configuration
+key.
+
+This takes a vector of patterns which largely behave like Unix-shell style
+"glob" patterns, although they differ from standard shell behavior in some
+subtle ways. These are processed using Java's
+[PathMatcher](https://docs.oracle.com/javase/10/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String))
+interface, the provided links describes how they work in detail.
+
+``` clojure
+#kaocha/v1
+{:kaocha.watch/ignore ["*.tmp"]}
+```
+
+When running in watch mode you can press the Enter (Return) key to manually
+trigger a re-run of the tests. This will always run all tests, not just the
+tests that failed on the last run.
+
+Interrupt the process (Ctrl-C) to exit Kaocha's watch mode.
+
+## Tips and tricks
+
+The `:kaocha.plugin/notifier` plugin will cause a system notification to pop up
+whenever a test run finishes. This works really well together with watch mode,
+as it means you can leave Kaocha running in the background, and only switch over
+when a test failed.
+
+Watch mode is most useful when it can provide quick feedback, this is why it's a
+good idea to combine it with `--fail-fast`, so you know as soon as possible when
+a test fails, and you can focus on one test at a time. You can disable
+randomization (`--no-randomize`) to prevent having to jump back and forth
+between different failing tests.
+
+If your test suites takes a long time to run then watch mode will be a lot less
+effective, in that case consider tagging your slowest tests with metadata, and
+filtering them out. (`--skip-meta :slow`)
+
+`tests.edn` is also watched for changes, and gets reloaded on every run, so
+there's a lot you can do without having to restart Kaocha.
+
+- enable `:fail-fast? true`
+- focus on specific tests or namespaces
+- enable extra plugins
+- set a fixed seed (when debugging ordering issue)
+- switch to a different reporter

--- a/doc/08_plugins.md
+++ b/doc/08_plugins.md
@@ -1,4 +1,4 @@
-# 7. Plugins
+# 8. Plugins
 
 This section describes plug-ins that are built-in but not enabled by default. Functionality of default plugins is described in the [Running Kaocha CLI](04_running_kaocha_cli.md) section.
 
@@ -92,3 +92,21 @@ FAIL in (clojure-test-summary-test) (kaocha/history_test.clj:5)
 
 bin/kaocha --focus 'kaocha.history-test/clojure-test-summary-test'
 ```
+
+## Notifier
+
+Pop up a system notifications whenever a test run fails or passes.
+
+See [Plugins: Notifier](plugins/notifier.md)
+
+## Version filter
+
+Skip tests that aren't compatible with the current version of Java or Clojure.
+
+See [Plugins: Version Filter](plugins/version_filter.md)
+
+## Hooks
+
+Write functions that hook into various parts of Kaocha
+
+See [Plugins: Hooks](plugins/hooks.md)

--- a/doc/command_line/fail_fast.md
+++ b/doc/command_line/fail_fast.md
@@ -1,4 +1,4 @@
-# `--fail-fast` option
+# CLI: `--fail-fast` option
 
 Kaocha by default runs all tests it can find, providing a final summary on
   failures and errors when all tests have finished. With the `--fail-fast`

--- a/doc/command_line/print_config.md
+++ b/doc/command_line/print_config.md
@@ -1,4 +1,4 @@
-# Print the Kaocha configuration
+# CLI: Print the Kaocha configuration
 
 A Kaocha test run starts with building up a Kaocha configuration map, based on
   default values, the contents of `tests.edn`, command line flags, and active

--- a/doc/command_line/reporter.md
+++ b/doc/command_line/reporter.md
@@ -1,4 +1,4 @@
-# `--reporter` option
+# CLI: `--reporter` option
 
 The progress and summary printed by Kaocha are done by one or more "reporter"
   functions. A reporter can be specified with the `--reporter` option followed

--- a/doc/command_line/suite_names.md
+++ b/doc/command_line/suite_names.md
@@ -1,4 +1,4 @@
-# Selecting test suites
+# CLI: Selecting test suites
 
 Each test suite has a unique id, given as a keyword in the test configuration.
   You can supply one or more of these ids on the command line to run only those

--- a/doc/plugins/capture_output.md
+++ b/doc/plugins/capture_output.md
@@ -1,4 +1,4 @@
-# Output capturing
+# Plugin: Capture output
 
 Kaocha has a plugin which will capture all output written to stdout or stderr
   during the test run. When tests pass this output is hidden, when they fail the

--- a/doc/plugins/hooks_plugin.md
+++ b/doc/plugins/hooks_plugin.md
@@ -1,4 +1,4 @@
-# Hooks plugin
+# Plugin: Hooks
 
 The hooks plugin allows hooking into Kaocha's process with arbitrary
   functions. This is very similar to using writing a plugin, but requires less
@@ -12,7 +12,7 @@ The hooks plugin allows hooking into Kaocha's process with arbitrary
 
 - <em>Given </em> a file named "tests.edn" with:
 
-``` nil
+``` clojure
 #kaocha/v1
 {:plugins [:kaocha.plugin/hooks]
  :kaocha.hooks/pre-test [my.kaocha.hooks/sample-hook]}

--- a/doc/plugins/notifier_plugin.md
+++ b/doc/plugins/notifier_plugin.md
@@ -1,6 +1,6 @@
-Feature: Plugin: Notifier (desktop notifications)
+# Plugin: Notifier (desktop notifications)
 
-  Desktop notifications can be enabled with the `:kaocha.plugin/notifier`
+Desktop notifications can be enabled with the `:kaocha.plugin/notifier`
   plugin. This will pop up a fail/pass notification bubble including a summary
   of tests passed/errored/failed at the end of each test run. It's particularly
   useful in combination with `--watch`, e.g. `bin/kaocha --plugin notifier
@@ -29,41 +29,54 @@ Feature: Plugin: Notifier (desktop notifications)
   the plugin will silently do nothing. You can explicitly inhibit its behaviour
   with `--no-notifications`.
 
-  Scenario: Enabling Desktop Notifications
-    Given a file named "tests.edn" with:
-    """ clojure
-    #kaocha/v1
-    {:plugins [:kaocha.plugin/notifier]
+## Enabling Desktop Notifications
 
-     ;; Configuring a command is optional. Since CI does not have desktop
-     ;; notifications we pipe to a file instead.
-     :kaocha.plugin.notifier/command
-     "sh -c 'echo \"%{title}\n%{message}\n%{failed?}\n%{count}\n%{urgency}\" > /tmp/kaocha.txt'"
+- <em>Given </em> a file named "tests.edn" with:
 
-     ;; Fallbacks:
+``` clojure
+#kaocha/v1
+{:plugins [:kaocha.plugin/notifier]
 
-     ;; :kaocha.plugin.notifier/command
-     ;; "notify-send -a Kaocha %{title} %{message} -i %{icon} -u %{urgency}"
+ ;; Configuring a command is optional. Since CI does not have desktop
+ ;; notifications we pipe to a file instead.
+ :kaocha.plugin.notifier/command
+ "sh -c 'echo \"%{title}\n%{message}\n%{failed?}\n%{count}\n%{urgency}\" > /tmp/kaocha.txt'"
 
-     ;; :kaocha.plugin.notifier/command
-     ;; "terminal-notifier -message %{message} -title %{title} -appIcon %{icon}"
-     }
-    """
-    And a file named "test/sample_test.clj" with:
-    """ clojure
-    (ns sample-test
-      (:require [clojure.test :refer :all]))
+ ;; Fallbacks:
 
-    (deftest simple-fail-test
-      (is (= :same :not-same)))
-    """
-    When I run `bin/kaocha`
-    And I run `cat /tmp/kaocha.txt`
-    Then the output should contain:
-    """
-    ⛔️ Failing
-    1 tests, 1 failures.
-    true
-    1
-    critical
-    """
+ ;; :kaocha.plugin.notifier/command
+ ;; "notify-send -a Kaocha %{title} %{message} -i %{icon} -u %{urgency}"
+
+ ;; :kaocha.plugin.notifier/command
+ ;; "terminal-notifier -message %{message} -title %{title} -appIcon %{icon}"
+ }
+```
+
+
+- <em>And </em> a file named "test/sample_test.clj" with:
+
+``` clojure
+(ns sample-test
+  (:require [clojure.test :refer :all]))
+
+(deftest simple-fail-test
+  (is (= :same :not-same)))
+```
+
+
+- <em>When </em> I run `bin/kaocha`
+
+- <em>And </em> I run `cat /tmp/kaocha.txt`
+
+- <em>Then </em> the output should contain:
+
+``` nil
+⛔️ Failing
+1 tests, 1 failures.
+true
+1
+critical
+```
+
+
+

--- a/doc/plugins/version_filter.md
+++ b/doc/plugins/version_filter.md
@@ -1,4 +1,4 @@
-# Limit tests to Clojure/Java versions
+# Plugin: Clojure/Java Version filter
 
 The `version-filter` plugin will look for test metadata specifying the minimum
   or maximum version of Clojure or Java the test is designed to work with, and

--- a/notes.org
+++ b/notes.org
@@ -39,7 +39,7 @@
 - [ ] Provide inspect plugin with e.g. --print-test-ids
 - [ ] Timing info of config/load/run steps
 - [ ] Provide extra dynamic var bindings
-- [ ] Global pre/post hooks
+- [X] Global pre/post hooks
 - [ ] test.check configuration
 - [ ] Detect side effects (see circleci.test)
 

--- a/src/kaocha/assertions.clj
+++ b/src/kaocha/assertions.clj
@@ -3,7 +3,8 @@
             [clojure.test :as t]
             [kaocha.report :as report]
             [puget.color :as color]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [slingshot.slingshot :refer [try+ throw+]]))
 
 (defmethod t/assert-expr 'substring? [msg form]
   (let [[_ s1 s2] form]
@@ -49,6 +50,19 @@
       :break
       (color/document printer ::long-sub long-sub)
       (show-trailing-whitespace remainder)])))
+
+#_
+(defmethod t/assert-expr 'thrown+? [msg form]
+  (let [expr (second form)
+        body (nthnext form 2)]
+    `(try+
+      ~@body
+      (t/do-report {:type :fail, :message ~msg,
+                    :expected '~form, :actual nil})
+      (catch ~expr e#
+        (t/do-report {:type :pass, :message ~msg,
+                      :expected '~form, :actual e#})
+        e#))))
 
 ;; Configured as a pre-load hook
 (defn load-assertions [config]

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -54,17 +54,19 @@
                 color?
                 fail-fast?
                 randomize?
+                capture-output?
                 watch?]} config
         tests            (some->> tests (mapv normalize-test-suite))]
     (cond-> {}
-      tests              (assoc :kaocha/tests (vary-meta tests assoc :replace true))
-      plugins            (assoc :kaocha/plugins plugins)
-      reporter           (assoc :kaocha/reporter (vary-meta reporter assoc :replace true))
-      (some? color?)     (assoc :kaocha/color? color?)
-      (some? fail-fast?) (assoc :kaocha/fail-fast? fail-fast?)
-      (some? watch?)     (assoc :kaocha/watch? watch?)
-      (some? randomize?) (assoc :kaocha.plugin.randomize/randomize? randomize?)
-      :->                (merge (dissoc config :tests :plugins :reporter :color? :fail-fast? :watch? :randomize?)))))
+      tests                   (assoc :kaocha/tests (vary-meta tests assoc :replace true))
+      plugins                 (assoc :kaocha/plugins plugins)
+      reporter                (assoc :kaocha/reporter (vary-meta reporter assoc :replace true))
+      (some? color?)          (assoc :kaocha/color? color?)
+      (some? fail-fast?)      (assoc :kaocha/fail-fast? fail-fast?)
+      (some? watch?)          (assoc :kaocha/watch? watch?)
+      (some? randomize?)      (assoc :kaocha.plugin.randomize/randomize? randomize?)
+      (some? capture-output?) (assoc :kaocha.plugin.capture-output/capture-output? capture-output?)
+      :->                     (merge (dissoc config :tests :plugins :reporter :color? :fail-fast? :watch? :randomize?)))))
 
 (defmethod aero/reader 'kaocha [opts tag value]
   (output/warn "The #kaocha reader literal is deprecated, please change it to #kaocha/v1.")

--- a/src/kaocha/monkey_patch.clj
+++ b/src/kaocha/monkey_patch.clj
@@ -74,4 +74,42 @@
 
        (merge file-and-line m)))))
 
+#_
+(defn assert-predicate
+  "Like clojure.test/assert-predicate, but get file/line from form metadata."
+  [msg form]
+  (let [args (rest form)
+        pred (first form)]
+    `(let [values# (list ~@args)
+           result# (apply ~pred values#)]
+       (if result#
+         (do-report {:type :pass, :message ~msg,
+                     :expected '~form, :actual (cons ~pred values#)
+                     :line ~(:line (or (meta (first form)) (meta form)))
+                     :file ~(:file (meta form))})
+         (do-report {:type :fail,
+                     :message ~msg,
+                     :expected '~form,
+                     :actual (list '~'not (cons '~pred values#))
+                     :line ~(:line (or (meta (first form)) (meta form)))
+                     :file ~(:file (meta form))}))
+       result#)))
+#_
+(defn assert-any
+  "Like clojure.test/assert-any, but get file/line from form metadata."
+  [msg form]
+  `(let [value# ~form]
+     (if value#
+       (do-report {:type :pass, :message ~msg,
+                   :expected '~form, :actual value#
+                   :line ~(:line (or (meta (first form)) (meta form)))
+                   :file ~(:file (meta form))})
+       (do-report {:type :fail, :message ~msg,
+                   :expected '~form, :actual value#
+                   :line ~(:line (or (meta (first form)) (meta form)))
+                   :file ~(:file (meta form))}))
+     value#))
+
 (alter-var-root #'t/do-report (constantly do-report))
+#_(alter-var-root #'t/assert-any (constantly assert-any))
+#_(alter-var-root #'t/assert-predicate (constantly assert-predicate))

--- a/src/kaocha/monkey_patch.clj
+++ b/src/kaocha/monkey_patch.clj
@@ -54,7 +54,9 @@
                                               (str/starts-with? cl-name "clojure.main$")
 
                                               (str/starts-with? cl-name "orchestra.")
+                                              (str/starts-with? cl-name "nrepl.")
 
+                                              (str/starts-with? cl-name "kaocha.repl")
                                               (str/starts-with? cl-name "kaocha.plugin.capture_output")
                                               (str/starts-with? cl-name "kaocha.monkey_patch$")
                                               (str/starts-with? cl-name "kaocha.runner")

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -102,7 +102,8 @@
 
       (:kaocha/watch? config)
       (do
-        ((jit kaocha.watch/run) config) 1) ; exit 1 because only an anomaly would break this loop
+        ((jit kaocha.watch/run) config)
+        @(promise))
 
       (:print-result options)
       (let [result (api/run (assoc config :kaocha/reporter []))

--- a/src/kaocha/specs.clj
+++ b/src/kaocha/specs.clj
@@ -39,8 +39,9 @@
 (s/def :kaocha.test-plan/tests (s/coll-of :kaocha.test-plan/testable))
 
 (s/def :kaocha.test-plan/testable (s/and :kaocha/testable
-                                         (s/keys :req [:kaocha.testable/desc]
-                                                 :opt [:kaocha.test-plan/tests
+                                         (s/keys :req []
+                                                 :opt [:kaocha.testable/desc
+                                                       :kaocha.test-plan/tests
                                                        :kaacha.test-plan/load-error])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/kaocha/watch.clj
+++ b/src/kaocha/watch.clj
@@ -3,6 +3,7 @@
   (:require [hawk.core :as hawk]
             [kaocha.api :as api]
             [kaocha.result :as result]
+            [kaocha.plugin :refer [defplugin]]
             [clojure.java.io :as io]
             [lambdaisland.tools.namespace.dir :as ctn-dir]
             [lambdaisland.tools.namespace.file :as ctn-file]
@@ -14,72 +15,184 @@
             [kaocha.testable :as testable]
             [kaocha.stacktrace :as stacktrace]
             [kaocha.output :as output]
-            [clojure.test :as t]))
+            [clojure.test :as t]
+            [kaocha.plugin :as plugin]
+            [kaocha.config :as config]
+            [kaocha.core-ext :refer :all])
+  (:import [java.nio.file FileSystems]))
 
-(defn- try-run [config]
-  (let [result (try
+(defn- try-run [config focus tracker]
+  (let [config (if (seq focus)
+                 (assoc config :kaocha.filter/focus focus)
+                 config)
+        config (-> config
+                   (assoc ::focus focus)
+                   (assoc ::tracker tracker)
+                   (update :kaocha/plugins #(cons ::plugin %)))
+        result (try
                  (api/run config)
                  (catch Throwable t
                    (println "[watch] Fatal error in test run" t)))]
     (println)
     result))
 
+(defn drain-queue! [q]
+  (doall (take-while identity (repeatedly #(.poll q)))))
+
+(defn track-reload! [tracker]
+  (binding [kaocha.api/*active?* true]
+    (ctn-reload/track-reload (assoc tracker ::ctn-file/load-error {}))))
+
+(defn print-scheduled-operations! [tracker focus]
+  (let [unload (set (::ctn-track/unload tracker))
+        load   (set (::ctn-track/load tracker))
+        reload (set/intersection unload load)
+        unload (set/difference unload reload)
+        load   (set/difference load reload)]
+    (when (seq unload)
+      (println "[watch] Unloading" unload))
+    (when (seq load)
+      (println "[watch] Loading" unload))
+    (when (seq reload)
+      (println "[watch] Reloading" reload))
+    (when (seq focus)
+      (println "[watch] Re-running failed tests" (set focus)))))
+
+(defn drain-and-rescan! [q tracker watch-paths]
+  (drain-queue! q)
+  (ctn-dir/scan-dirs tracker watch-paths))
+
+(defn glob?
+  "Does path match any of the glob patterns.
+
+  See [FileSystem/getPathMatcher](https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String))
+  for a description of the patterns, these are similar but not the same as
+  typical shell glob patterns. "
+  [path patterns]
+  (let [fs (FileSystems/getDefault)
+        patterns (map #(.getPathMatcher fs (str "glob:" %)) patterns)]
+    (some #(.matches % path) patterns)))
+
+(defn wait-and-rescan! [q tracker watch-paths ignore]
+  (let [f (.take q)]
+    (if (and (file? f) (glob? (.toPath f) ignore))
+      (recur q tracker watch-paths ignore)
+      [(drain-and-rescan! q tracker watch-paths) f])))
+
+(defn reload-config [config]
+  (let [{:kaocha/keys [cli-options cli-args]} config
+        {:keys [config-file plugin]}          cli-options
+
+        config       (-> config-file
+                         (config/load-config)
+                         (config/apply-cli-opts cli-options)
+                         (config/apply-cli-args cli-args))
+        plugin-chain (plugin/load-all (concat (:kaocha/plugins config) plugin))]
+    [config plugin-chain]))
+
+(defn run-loop [config tracker q watch-paths]
+  (loop [tracker      tracker
+         config       config
+         plugin-chain plugin/*current-chain*
+         focus        nil]
+
+    (let [result  (try-run config focus tracker)
+          tracker (::tracker result)
+          error   (::error result)
+          ignore  (::ignore config)]
+
+      (cond
+        error
+        (do
+          (println "[watch] Error reloading, all tests skipped.")
+          (let [[tracker _] (wait-and-rescan! q tracker watch-paths ignore)
+                [config plugin-chain] (reload-config config)]
+            (recur tracker config plugin-chain nil)))
+
+        (and (seq focus) (not (result/failed? result)))
+        (do
+          (println "[watch] Failed tests pass, re-running all tests.")
+          (recur (drain-and-rescan! q tracker watch-paths) config plugin-chain nil))
+
+        :else
+        (let [[tracker trigger] (wait-and-rescan! q tracker watch-paths ignore)
+              [config plugin-chain] (reload-config config)
+              focus (when-not (= :enter trigger)
+                      (->> result
+                           testable/test-seq
+                           (filter result/failed-one?)
+                           (map ::testable/id)))]
+          (recur tracker config plugin-chain focus))))))
+
+(defplugin kaocha.watch/plugin
+  "This is an internal plugin, don't use it directly.
+
+Behind the scenes we add this plugin to the start of the plugin chain. It takes
+care of reloading namespaces inside a Kaocha run, so we can report any load
+errors as test errors."
+  (pre-load [{::keys [tracker focus] :as config}]
+    (print-scheduled-operations! tracker focus)
+    (let [tracker    (track-reload! tracker)
+          config     (assoc config ::tracker tracker)
+          error      (::ctn-reload/error tracker)
+          error-ns   (::ctn-reload/error-ns tracker)
+          load-error (::ctn-file/load-error tracker)]
+      (if (and error error-ns)
+        (-> config
+            (assoc ::error error ::error-ns error-ns)
+            (update :kaocha/tests
+                    (partial map (fn [t] (assoc t :kaocha.testable/skip true)))))
+        config)))
+
+  (pre-test [test test-plan]
+    (if-let [error (::error test-plan)]
+      (do
+        (t/do-report {:type :error
+                      :kaocha/testable {:kaocha.testable/id :kaocha/watch}
+                      :message (str "Failed reloading ns: " (::error-ns test-plan))
+                      :actual error})
+        (assoc test
+               :kaocha.result/count 1
+               :kaocha.result/error 1
+               ::testable/skip-remaining? true))
+      test)))
+
+(defn watch-paths [config]
+  (into #{}
+        (comp (remove :kaocha.testable/skip)
+              (map (juxt :kaocha/test-paths :kaocha/source-paths))
+              cat
+              cat
+              (map io/file))
+        (:kaocha/tests config)))
+
+(defn watch! [q watch-paths]
+  (hawk/watch! [{:paths   watch-paths
+                 :handler (fn [ctx event]
+                            (when (= (:kind event) :modify)
+                              (.put q (:file event))))}]))
+
 (defn run [config]
-  (let [watch-paths       (into #{} (comp (remove :kaocha.testable/skip)
-                                          (map (juxt :kaocha/test-paths :kaocha/source-paths))
-                                          cat
-                                          cat
-                                          (map io/file))
-                                (:kaocha/tests config))
-        watch-chan        (java.util.concurrent.ArrayBlockingQueue. 1024)
-        drain-watch-chan! (fn [] (doall (take-while identity (repeatedly #(.poll watch-chan)))))
-        tracker           (-> (ctn-track/tracker)
-                              (ctn-dir/scan-dirs watch-paths)
-                              (dissoc :lambdaisland.tools.namespace.track/unload
-                                      :lambdaisland.tools.namespace.track/load))]
+  (let [watch-paths (watch-paths config)
+        q           (java.util.concurrent.ArrayBlockingQueue. 1024)
+        tracker     (-> (ctn-track/tracker)
+                        (ctn-dir/scan-dirs watch-paths)
+                        (dissoc :lambdaisland.tools.namespace.track/unload
+                                :lambdaisland.tools.namespace.track/load))]
     (future
       (try
-        (loop [tracker tracker
-               focus   nil]
-          (let [unload     (set (::ctn-track/unload tracker))
-                load       (set (::ctn-track/load tracker))
-                load-error (::ctn-file/load-error tracker)
-                reload     (set/intersection unload load)
-                unload     (set/difference unload reload)
-                load       (set/difference load reload)
-                tracker    (ctn-reload/track-reload (assoc tracker ::ctn-file/load-error {}))]
-            (when (seq load-error)
-              (doseq [[f e] load-error]
-                (output/warn "Failed loading" f)
-                (stacktrace/print-cause-trace e t/*stack-trace-depth*)))
-
-            (when (seq unload) (println "[watch] Unloading" unload))
-            (when (seq load) (println "[watch] Loading" unload))
-            (when (seq reload) (println "[watch] Reloading" reload))
-            (when (seq focus) (println "[watch] Re-running failed tests" (set focus)))
-
-            (let [config' (cond-> config (seq focus) (assoc :kaocha.filter/focus focus))
-                  result  (try-run config')]
-              (if (and (seq focus) (not (result/failed? result)))
-                (do
-                  (println "[watch] Failed tests pass, re-running all tests.")
-                  (drain-watch-chan!)
-                  (recur (ctn-dir/scan-dirs tracker watch-paths) nil))
-                (let [f (.take watch-chan)]
-                  (drain-watch-chan!)
-                  (recur (ctn-dir/scan-dirs tracker watch-paths)
-                         (->> result
-                              testable/test-seq
-                              (filter result/failed-one?)
-                              (map ::testable/id))))))))
+        (run-loop config tracker q watch-paths)
         (catch Throwable t
           (.printStackTrace t))
         (finally
           (println "[watch] loop broken"))))
 
-    (hawk/watch! [{:paths   watch-paths
-                   :handler (fn [ctx event]
-                              (when (= (:kind event) :modify)
-                                (.put watch-chan (:file event))))}])
+    (watch! q watch-paths)
+    (watch! q [(get-in config [:kaocha/cli-options :config-file])])
+
+    (future
+      (while true
+        (.readLine (io/reader System/in))
+        (.put q :enter)))
 
     @(promise)))

--- a/test/features/command_line/fail_fast.feature
+++ b/test/features/command_line/fail_fast.feature
@@ -1,4 +1,4 @@
-Feature: `--fail-fast` option
+Feature: CLI: `--fail-fast` option
 
   Kaocha by default runs all tests it can find, providing a final summary on
   failures and errors when all tests have finished. With the `--fail-fast`

--- a/test/features/command_line/print_config.feature
+++ b/test/features/command_line/print_config.feature
@@ -1,4 +1,4 @@
-Feature: Print the Kaocha configuration
+Feature: CLI: Print the Kaocha configuration
 
   A Kaocha test run starts with building up a Kaocha configuration map, based on
   default values, the contents of `tests.edn`, command line flags, and active

--- a/test/features/command_line/reporter.feature
+++ b/test/features/command_line/reporter.feature
@@ -1,4 +1,4 @@
-Feature: `--reporter` option
+Feature: CLI: `--reporter` option
 
   The progress and summary printed by Kaocha are done by one or more "reporter"
   functions. A reporter can be specified with the `--reporter` option followed

--- a/test/features/command_line/suite_names.feature
+++ b/test/features/command_line/suite_names.feature
@@ -1,4 +1,4 @@
-Feature: Selecting test suites
+Feature: CLI: Selecting test suites
 
   Each test suite has a unique id, given as a keyword in the test configuration.
   You can supply one or more of these ids on the command line to run only those

--- a/test/features/plugins/capture_output.feature
+++ b/test/features/plugins/capture_output.feature
@@ -1,4 +1,4 @@
-Feature: Output capturing
+Feature: Plugin: Capture output
 
   Kaocha has a plugin which will capture all output written to stdout or stderr
   during the test run. When tests pass this output is hidden, when they fail the

--- a/test/features/plugins/hooks_plugin.feature
+++ b/test/features/plugins/hooks_plugin.feature
@@ -1,4 +1,4 @@
-Feature: Hooks plugin
+Feature: Plugin: Hooks
 
   The hooks plugin allows hooking into Kaocha's process with arbitrary
   functions. This is very similar to using writing a plugin, but requires less

--- a/test/features/plugins/version_filter.feature
+++ b/test/features/plugins/version_filter.feature
@@ -1,4 +1,4 @@
-Feature: Limit tests to Clojure/Java versions
+Feature: Plugin: Clojure/Java Version filter
 
   The `version-filter` plugin will look for test metadata specifying the minimum
   or maximum version of Clojure or Java the test is designed to work with, and

--- a/test/shared/kaocha/integration_helpers.clj
+++ b/test/shared/kaocha/integration_helpers.clj
@@ -1,0 +1,116 @@
+(ns kaocha.integration-helpers
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str])
+  (:import java.io.File
+           [java.nio.file Files OpenOption Path Paths]
+           [java.nio.file.attribute FileAttribute PosixFilePermissions]))
+
+(require 'kaocha.assertions)
+
+(defprotocol Joinable
+  (join [this that]))
+
+(extend-protocol Joinable
+  String
+  (join [this that] (join (Paths/get this (make-array String 0)) that))
+  Path
+  (join [this that] (.resolve this (str that)))
+  File
+  (join [this that] (.toPath (io/file this (str that)))))
+
+(extend-protocol io/IOFactory
+  Path
+  (make-output-stream [this opts]
+    (Files/newOutputStream this (into-array OpenOption [])))
+  (make-input-stream [this opts]
+    (Files/newInputStream this (into-array OpenOption [])))
+  (make-writer [this opts]
+    (io/make-writer (io/make-output-stream this opts) opts))
+  (make-reader [this opts]
+    (io/make-reader (io/make-input-stream this opts) opts)))
+
+(extend-protocol io/Coercions
+  Path
+  (as-file [path] (.toFile path))
+  (as-url [path] (.toURL (.toFile path))))
+
+(def default-attributes (into-array FileAttribute []))
+
+(defn temp-dir
+  ([]
+   (temp-dir "kaocha_integration"))
+  ([path]
+   (Files/createTempDirectory path default-attributes)))
+
+(defonce clj-cpcache-dir (temp-dir "kaocha_cpcache"))
+
+(defn mkdir [path]
+  (Files/createDirectories path default-attributes))
+
+(defn codecov? []
+  (= (System/getenv "CI") "true"))
+
+(defn project-dir-path [& paths]
+  (str (reduce join (.getAbsolutePath (io/file "")) paths)))
+
+(defmacro with-print-namespace-maps [bool & body]
+  (if (find-var 'clojure.core/*print-namespace-maps*)
+    `(binding [*print-namespace-maps* ~bool]
+       ~@body)
+    ;; pre Clojure 1.9
+    `(do ~@body)))
+
+(defn write-deps-edn [path]
+  (with-open [deps-out (io/writer path)]
+    (binding [*out* deps-out]
+      (with-print-namespace-maps false
+        (clojure.pprint/pprint {:deps {'lambdaisland/kaocha           {:local/root (project-dir-path)}
+                                       'lambdaisland/kaocha-cloverage {:mvn/version "RELEASE"}}})))))
+
+(defn test-dir-setup [m]
+  (if (:dir m)
+    m
+    (let [dir         (temp-dir)
+          test-dir    (join dir "test")
+          bin-dir     (join dir "bin")
+          config-file (join dir "tests.edn")
+          deps-edn    (join dir "deps.edn")
+          runner      (join dir "bin/kaocha")]
+      (mkdir test-dir)
+      (mkdir bin-dir)
+      (spit (str config-file)
+            (str "#kaocha/v1\n"
+                 "{:color? false\n"
+                 " :randomize? false}"))
+      (spit (str runner)
+            (str/join " "
+                      (cond-> ["clojure"
+                               "-m" "kaocha.runner"]
+                        (codecov?)
+                        (into ["--plugin" "cloverage"
+                               "--cov-output" (project-dir-path "target/coverage" (str (gensym "integration")))
+                               "--cov-src-ns-path" (project-dir-path "src")
+                               "--codecov"])
+                        :always
+                        (conj "\"$@\""))))
+      (write-deps-edn deps-edn)
+      (Files/setPosixFilePermissions runner (PosixFilePermissions/fromString "rwxr--r--"));
+      (assoc m
+             :dir dir
+             :test-dir test-dir
+             :config-file config-file
+             :runner runner))))
+
+(defn ns->fname [ns]
+  (-> ns
+      str
+      (str/replace #"\." "/")
+      (str/replace #"-" "_")
+      (str ".clj")))
+
+(defn spit-file [m path contents]
+  (let [{:keys [dir] :as m} (test-dir-setup m)
+        path (join dir path)]
+    (mkdir (.getParent path))
+    (spit path contents)
+    m))

--- a/test/step_definitions/kaocha_integration.clj
+++ b/test/step_definitions/kaocha_integration.clj
@@ -2,125 +2,17 @@
   (:require [clojure.java.io :as io]
             [clojure.java.shell :as shell]
             [clojure.string :as str]
-            [clojure.test :refer :all]
+            [clojure.test :as t :refer :all]
+            [kaocha.integration-helpers :refer :all]
             [kaocha.output :as output]
             [kaocha.shellwords :refer [shellwords]]
             [lambdaisland.cucumber.dsl :refer :all]
-            [me.raynes.fs :as fs]
-            [clojure.test :as t])
-  (:import java.io.File
-           [java.nio.file Files OpenOption Path Paths]
-           [java.nio.file.attribute FileAttribute PosixFilePermissions]))
+            [me.raynes.fs :as fs]))
 
 (require 'kaocha.assertions)
 
-(defprotocol Joinable
-  (join [this that]))
-
-(extend-protocol Joinable
-  String
-  (join [this that] (join (Paths/get this (make-array String 0)) that))
-  Path
-  (join [this that] (.resolve this (str that)))
-  File
-  (join [this that] (.toPath (io/file this (str that)))))
-
-(extend-protocol io/IOFactory
-  Path
-  (make-output-stream [this opts]
-    (Files/newOutputStream this (into-array OpenOption [])))
-  (make-input-stream [this opts]
-    (Files/newInputStream this (into-array OpenOption [])))
-  (make-writer [this opts]
-    (io/make-writer (io/make-output-stream this opts) opts))
-  (make-reader [this opts]
-    (io/make-reader (io/make-input-stream this opts) opts)))
-
-(extend-protocol io/Coercions
-  Path
-  (as-file [path] (.toFile path))
-  (as-url [path] (.toURL (.toFile path))))
-
-(def default-attributes (into-array FileAttribute []))
-
-(defn temp-dir
-  ([]
-   (temp-dir "kaocha_integration"))
-  ([path]
-   (Files/createTempDirectory path default-attributes)))
-
-(defonce clj-cpcache-dir (temp-dir "kaocha_cpcache"))
-
-(defn mkdir [path]
-  (Files/createDirectories path default-attributes))
-
-(defn codecov? []
-  (= (System/getenv "CI") "true"))
-
-(defn project-dir-path [& paths]
-  (str (reduce join (.getAbsolutePath (io/file "")) paths)))
-
-(defmacro with-print-namespace-maps [bool & body]
-  (if (find-var 'clojure.core/*print-namespace-maps*)
-    `(binding [*print-namespace-maps* ~bool]
-       ~@body)
-    ;; pre Clojure 1.9
-    `(do ~@body)))
-
-(defn write-deps-edn [path]
-  (with-open [deps-out (io/writer path)]
-    (binding [*out* deps-out]
-      (with-print-namespace-maps false
-        (clojure.pprint/pprint {:deps {'lambdaisland/kaocha           {:local/root (project-dir-path)}
-                                       'lambdaisland/kaocha-cloverage {:mvn/version "RELEASE"}}})))))
-
-(defn test-dir-setup [m]
-  (if (:dir m)
-    m
-    (let [dir         (temp-dir)
-          test-dir    (join dir "test")
-          bin-dir     (join dir "bin")
-          config-file (join dir "tests.edn")
-          deps-edn    (join dir "deps.edn")
-          runner      (join dir "bin/kaocha")]
-      (mkdir test-dir)
-      (mkdir bin-dir)
-      (spit (str config-file)
-            (str "#kaocha/v1\n"
-                 "{:color? false\n"
-                 " :randomize? false}"))
-      (spit (str runner)
-            (str/join " "
-                      (cond-> ["clojure"
-                               "-m" "kaocha.runner"]
-                        (codecov?)
-                        (into ["--plugin" "cloverage"
-                               "--cov-output" (project-dir-path "target/coverage" (str (gensym "integration")))
-                               "--cov-src-ns-path" (project-dir-path "src")
-                               "--codecov"])
-                        :always
-                        (conj "\"$@\""))))
-      (write-deps-edn deps-edn)
-      (Files/setPosixFilePermissions runner (PosixFilePermissions/fromString "rwxr--r--"));
-      (assoc m
-             :dir dir
-             :test-dir test-dir
-             :config-file config-file
-             :runner runner))))
-
-(defn ns->fname [ns]
-  (-> ns
-      str
-      (str/replace #"\." "/")
-      (str/replace #"-" "_")
-      (str ".clj")))
-
 (Given "a file named {string} with:" [m path contents]
-  (let [{:keys [dir] :as m} (test-dir-setup m)
-        path (join dir path)]
-    (mkdir (.getParent path))
-    (spit path contents)
-    m))
+  (spit-file m path contents))
 
 (def last-cpcache-dir (atom nil))
 

--- a/test/unit/kaocha/config_test.clj
+++ b/test/unit/kaocha/config_test.clj
@@ -76,7 +76,13 @@
 
   (testing "normalizes test suites"
     (is (match? {:kaocha/tests [{:kaocha.testable/id :unit}]}
-                (c/normalize {:tests [{}]})))))
+                (c/normalize {:tests [{}]}))))
+
+  (testing "knows about randomize? and capture-output?"
+    (is (match? {:kaocha.plugin.capture-output/capture-output? :sentinel1
+                 :kaocha.plugin.randomize/randomize? :sentinel2}
+                (c/normalize {:capture-output? :sentinel1
+                              :randomize? :sentinel2})))))
 
 (deftest load-config-test []
   (testing "loads the config file in the project root"

--- a/test/unit/kaocha/report_test.clj
+++ b/test/unit/kaocha/report_test.clj
@@ -281,18 +281,21 @@
 
   (is (= "\n    level1\n      level2"
          (with-test-out-str
-           (binding [t/*testing-contexts* ["level2" "level1"]]
-             (r/doc {:type :pass})))))
+           (with-redefs [r/doc-printed-contexts (atom nil)]
+             (binding [t/*testing-contexts* ["level2" "level1"]]
+               (r/doc {:type :pass}))))))
 
-  (is (= "[31m ERROR[m"
+  (is (= "\n    level1\n      level2[31m ERROR[m"
          (with-test-out-str
-           (binding [t/*testing-contexts* ["level2" "level1"]]
-             (r/doc {:type :error}))) ))
+           (with-redefs [r/doc-printed-contexts (atom nil)]
+             (binding [t/*testing-contexts* ["level2" "level1"]]
+               (r/doc {:type :error}))))))
 
-  (is (= "[31m FAIL[m"
+  (is (= "\n    level1\n      level2[31m FAIL[m"
          (with-test-out-str
-           (binding [t/*testing-contexts* ["level2" "level1"]]
-             (r/doc {:type :fail}))) ))
+           (with-redefs [r/doc-printed-contexts (atom nil)]
+             (binding [t/*testing-contexts* ["level2" "level1"]]
+               (r/doc {:type :fail}))))))
 
   (is (= "\n"
          (with-test-out-str

--- a/test/unit/kaocha/report_test.clj
+++ b/test/unit/kaocha/report_test.clj
@@ -326,6 +326,8 @@
 (comment
   (do
     (require 'kaocha.repl)
-    (kaocha.repl/run))
+    (kaocha.repl/run)
+
+    )
 
   )

--- a/test/unit/kaocha/watch_test.clj
+++ b/test/unit/kaocha/watch_test.clj
@@ -1,0 +1,54 @@
+(ns kaocha.watch-test
+  (:require [clojure.test :refer :all]
+            [kaocha.watch :as w]
+            [lambdaisland.tools.namespace.dir :as ctn-dir]
+            [lambdaisland.tools.namespace.track :as ctn-track]
+            [clojure.java.io :as io])
+  (:import [java.io File]))
+
+(deftest make-queue-test
+  (is (instance? java.util.concurrent.BlockingQueue (w/make-queue))))
+
+(deftest put-poll-test
+  (let [q (w/make-queue)]
+    (w/qput q :x)
+    (w/qput q :y)
+    (is (= :x (w/qpoll q)))
+    (is (= :y (w/qpoll q)))))
+
+(deftest drain-queue-test
+  (let [q (w/make-queue)]
+    (w/qput q :x)
+    (w/qput q :y)
+    (w/drain-queue! q)
+    (is (empty? q))))
+
+(def freshly-loaded? true)
+
+(deftest track-reload!-test
+  (alter-var-root #'freshly-loaded? (constantly false))
+  (let [tracker (-> (ctn-track/tracker)
+                    (ctn-dir/scan-dirs ["test/unit/kaocha/watch_test.clj"])
+                    w/track-reload!)]
+    (is @(find-var `freshly-loaded?))))
+
+(deftest print-scheduled-operations-test
+  (is (= "[watch] Unloading #{baq.ok}
+[watch] Loading #{bar.baz}
+[watch] Reloading #{foo.bar}
+[watch] Re-running failed tests #{foos.ball}\n"
+         (with-out-str
+           (w/print-scheduled-operations! {::ctn-track/load '(foo.bar bar.baz)
+                                           ::ctn-track/unload '(foo.bar baq.ok)}
+                                          '[foos.ball])))))
+
+(deftest glob-test
+  (is (w/glob? (.toPath (io/file "xxxx.clj")) ["xxx*"]))
+  (is (not (w/glob? (.toPath (io/file "xxxx.clj")) ["xxy*"]))))
+
+(deftest reload-config-test
+  (is (match?
+       {:kaocha/tests [{:kaocha.testable/id :foo}]}
+       (let [tmp-file (File/createTempFile "tests" ".edn")]
+         (spit tmp-file "#kaocha/v1 {:tests [{:id :foo}]}")
+         (first (w/reload-config {:kaocha/cli-options {:config-file (str tmp-file)}}))))))

--- a/test/unit/kaocha/watch_test.clj
+++ b/test/unit/kaocha/watch_test.clj
@@ -1,9 +1,15 @@
 (ns kaocha.watch-test
   (:require [clojure.test :refer :all]
             [kaocha.watch :as w]
+            [kaocha.test-util :as util]
             [lambdaisland.tools.namespace.dir :as ctn-dir]
             [lambdaisland.tools.namespace.track :as ctn-track]
-            [clojure.java.io :as io])
+            [lambdaisland.tools.namespace.reload :as ctn-reload]
+            [kaocha.integration-helpers :as integration]
+            [clojure.java.io :as io]
+            [kaocha.config :as config]
+            [clojure.test :as t]
+            [clojure.string :as str])
   (:import [java.io File]))
 
 (deftest make-queue-test
@@ -52,3 +58,32 @@
        (let [tmp-file (File/createTempFile "tests" ".edn")]
          (spit tmp-file "#kaocha/v1 {:tests [{:id :foo}]}")
          (first (w/reload-config {:kaocha/cli-options {:config-file (str tmp-file)}}))))))
+
+(deftest watch-test
+  (let [{:keys [config-file test-dir] :as m} (integration/test-dir-setup {})
+        config (-> (config/load-config config-file)
+                   (assoc-in [:kaocha/cli-options :config-file] (str config-file))
+                   (assoc-in [:kaocha/tests 0 :kaocha/source-paths] [])
+                   (assoc-in [:kaocha/tests 0 :kaocha/test-paths] [(str test-dir)]))
+        prefix (str (gensym "foo"))
+        finish? (atom false)
+        q       (w/make-queue)
+        out-str (promise)]
+    (integration/spit-file m "tests.edn" (prn-str config))
+    (integration/spit-file m (str "test/" prefix "/bar_test.clj") (str "(ns " prefix ".bar-test (:require [clojure.test :refer :all])) (deftest xxx-test (is (= :xxx :yyy)))"))
+
+    (future (deliver out-str (util/with-test-out-str
+                               (t/with-test-out
+                                 (util/with-test-ctx
+                                   (w/run* config finish? q))))))
+
+    (Thread/sleep 100)
+    (integration/spit-file m (str "test/" prefix "/bar_test.clj") (str "(ns " prefix ".bar-test (:require [clojure.test :refer :all])) (deftest xxx-test (is (= :xxx :zzz)))"))
+    (Thread/sleep 100)
+    (reset! finish? true)
+    (w/qput q :finish)
+
+    (is (str/replace "[(F)]\n\nFAIL in foo.bar-test/xxx-test (bar_test.clj:1)\nExpected:\n  :xxx\nActual:\n  -:xxx +:yyy\n1 tests, 1 assertions, 1 failures.\n\n[watch] Reloading #{foo.bar-test}\n[watch] Re-running failed tests #{:foo.bar-test/xxx-test}\n[(F)]\n\nFAIL in foo.bar-test/xxx-test (bar_test.clj:1)\nExpected:\n  :xxx\nActual:\n  -:xxx +:zzz\n1 tests, 1 assertions, 1 failures.\n\n[watch] watching stopped.\n"
+                     "foo"
+                     prefix)
+        @out-str)))

--- a/tests.edn
+++ b/tests.edn
@@ -5,10 +5,12 @@
            :kaocha.plugin/notifier]
 
  :tests   [{:id         :unit
-            :test-paths ["test/shared" "test/unit"]}
+            :test-paths ["test/shared"
+                         "test/unit"]}
            {:id                  :integration
             :type                :kaocha.type/cucumber
-            :test-paths          ["test/features"]
+            :test-paths          ["test/shared"
+                                  "test/features"]
             :cucumber/glue-paths ["test/step_definitions"]}]
 
  :kaocha.hooks/pre-load [kaocha.assertions/load-assertions]}


### PR DESCRIPTION
I've tried to address as many of the concerns and issues with --watch as
possible. In the process I've cleaned up the code quite a bit, but it's also
gotten quite a bit more complex, and it's still basically untested because this
stuff is a pain to test, but I've tried to dogfood it as much as possible.

The big issue is that is fixed is that load errors are handled much better. Now
if a namespace fails to load you'll get to see the relevant exception and trace,
and the whole thing is reported as if it's a failing test run. That way plugins
and reporters like the notifier plugin can also report on it. We no longer try
to do an actual run in this case, all tests are skipped.

Pressing enter will re-run all tests (not just previously failing tests).

You can set patterns for files to ignore in `tests.edn` (:kaocha.watch/ignore
[...]). These follow the glob spec of java's PatchMatcher. The original idea was
to source these from .gitignore, but .gitignore uses a pretty specific format,
so we'd have to parse and convert that, that's something for later.

Finally `tests.edn` will also be watched, and it gets reloaded on every run, so
you can change your config and add plugins on the fly.

Closes #16 
Closes #17 
Closes #39 