### PR TITLE
Add a bindings plugin to add dynamic bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   of `:kaocha.plugin.capture-output/capture-output? false`. Since this is a
   built-in plugin that's enabled by default it makes sense to provide a
   shorthand for this.
+- Added a `:kaocha.plugin/bindings` plugin that allows setting dynamic var
+  bindings from `tests.edn`
 
 ## Fixed
 

--- a/doc/plugins/bindings.md
+++ b/doc/plugins/bindings.md
@@ -1,0 +1,39 @@
+# Plugin: Bindings
+
+The `bindings` plugin allows you to configure dynamic var bindings from
+  `tests.edn`, so they are visible during the test run.
+
+## Implementing a hook
+
+- <em>Given </em> a file named "tests.edn" with:
+
+``` clojure
+#kaocha/v1
+{:plugins [:kaocha.plugin/bindings]
+ :kaocha/bindings {my.foo-test/*a-var* 456}}
+```
+
+
+- <em>And </em> a file named "test/my/foo_test.clj" with:
+
+``` clojure
+(ns my.foo-test
+  (:require [clojure.test :refer :all]))
+
+(def ^:dynamic *a-var* 123)
+
+(deftest var-test
+  (is (= 456 *a-var*)))
+```
+
+
+- <em>When </em> I run `bin/kaocha`
+
+- <em>Then </em> the output should contain:
+
+``` nil
+1 tests, 1 assertions, 0 failures.
+```
+
+
+

--- a/src/kaocha/plugin/bindings.clj
+++ b/src/kaocha/plugin/bindings.clj
@@ -1,0 +1,15 @@
+(ns kaocha.plugin.bindings
+  (:require [kaocha.plugin :refer [defplugin]]))
+
+(defplugin kaocha.plugin/bindings
+  "Set dynamic bindings during the test run."
+  (wrap-run [run test-plan]
+    (if-let [bindings (:kaocha/bindings test-plan)]
+      (let [bindings (into {} (map (fn [[k v]] [(find-var k) v])) bindings)]
+        (fn [& args]
+          (try
+            (push-thread-bindings bindings)
+            (apply run args)
+            (finally
+              (pop-thread-bindings)))))
+      run)))

--- a/test/features/plugins/bindings.feature
+++ b/test/features/plugins/bindings.feature
@@ -1,0 +1,27 @@
+Feature: Plugin: Bindings
+
+  The `bindings` plugin allows you to configure dynamic var bindings from
+  `tests.edn`, so they are visible during the test run.
+
+  Scenario: Implementing a hook
+    Given a file named "tests.edn" with:
+    """ clojure
+    #kaocha/v1
+    {:plugins [:kaocha.plugin/bindings]
+     :kaocha/bindings {my.foo-test/*a-var* 456}}
+    """
+    And a file named "test/my/foo_test.clj" with:
+    """ clojure
+    (ns my.foo-test
+      (:require [clojure.test :refer :all]))
+
+    (def ^:dynamic *a-var* 123)
+
+    (deftest var-test
+      (is (= 456 *a-var*)))
+    """
+    When I run `bin/kaocha`
+    Then the output should contain:
+    """
+    1 tests, 1 assertions, 0 failures.
+    """


### PR DESCRIPTION
Configure dynamic bindings from `tests.edn`.

```
#kaocha/v1
{:plugins [:kaocha.plugin/bindings]
 :kaocha/bindings {some-dynamic/*var* 123}}
```

Closes #59