### PR TITLE
Fix docs: Plugin names should be keywords

### DIFF
--- a/doc/08_plugins.md
+++ b/doc/08_plugins.md
@@ -18,7 +18,7 @@ or
 
 ``` clojure
 #kaocha/v1
-{:plugins [kaocha.plugin/profiling]}
+{:plugins [:kaocha.plugin/profiling]}
 ```
 
 ### Example output
@@ -78,7 +78,7 @@ or
 
 ``` clojure
 #kaocha/v1
-{:plugins [kaocha.plugin/print-invocations]}
+{:plugins [:kaocha.plugin/print-invocations]}
 ```
 
 ### Example output


### PR DESCRIPTION
I stumbled over this in the docs.