### PR TITLE
Stop the watcher from reacting to directory events

### DIFF
--- a/src/kaocha/core_ext.clj
+++ b/src/kaocha/core_ext.clj
@@ -19,7 +19,10 @@
   (instance? clojure.lang.Namespace x))
 
 (defn file? [x]
-  (instance? java.io.File x))
+  (and (instance? java.io.File x) (.isFile x)))
+
+(defn directory? [x]
+  (and (instance? java.io.File x) (.isDirectory x)))
 
 (defn path? [x]
   (instance? java.nio.file.Path x))

--- a/src/kaocha/watch.clj
+++ b/src/kaocha/watch.clj
@@ -1,24 +1,24 @@
 (ns kaocha.watch
   (:refer-clojure :exclude [symbol])
-  (:require [hawk.core :as hawk]
+  (:require [clojure.java.io :as io]
+            [clojure.set :as set]
+            [clojure.string :as str]
+            [clojure.test :as t]
+            [hawk.core :as hawk]
             [kaocha.api :as api]
-            [kaocha.result :as result]
+            [kaocha.config :as config]
+            [kaocha.core-ext :refer :all]
+            [kaocha.output :as output]
+            [kaocha.plugin :as plugin]
             [kaocha.plugin :refer [defplugin]]
-            [clojure.java.io :as io]
+            [kaocha.result :as result]
+            [kaocha.stacktrace :as stacktrace]
+            [kaocha.testable :as testable]
             [lambdaisland.tools.namespace.dir :as ctn-dir]
             [lambdaisland.tools.namespace.file :as ctn-file]
             [lambdaisland.tools.namespace.parse :as ctn-parse]
             [lambdaisland.tools.namespace.reload :as ctn-reload]
-            [lambdaisland.tools.namespace.track :as ctn-track]
-            [clojure.string :as str]
-            [clojure.set :as set]
-            [kaocha.testable :as testable]
-            [kaocha.stacktrace :as stacktrace]
-            [kaocha.output :as output]
-            [clojure.test :as t]
-            [kaocha.plugin :as plugin]
-            [kaocha.config :as config]
-            [kaocha.core-ext :refer :all])
+            [lambdaisland.tools.namespace.track :as ctn-track])
   (:import [java.nio.file FileSystems]
            [java.util.concurrent ArrayBlockingQueue BlockingQueue]))
 
@@ -89,6 +89,9 @@
   (let [f (qtake q)]
     (cond
       (and (file? f) (glob? (.toPath f) ignore))
+      (recur q tracker watch-paths ignore)
+
+      (directory? f)
       (recur q tracker watch-paths ignore)
 
       (= :finish f)

--- a/test/shared/kaocha/integration_helpers.clj
+++ b/test/shared/kaocha/integration_helpers.clj
@@ -108,6 +108,12 @@
       (str/replace #"-" "_")
       (str ".clj")))
 
+(defn spit-dir [m path]
+  (let [{:keys [dir] :as m} (test-dir-setup m)
+        path (join dir path)]
+    (mkdir path)
+    m))
+
 (defn spit-file [m path contents]
   (let [{:keys [dir] :as m} (test-dir-setup m)
         path (join dir path)]

--- a/test/unit/kaocha/watch_test.clj
+++ b/test/unit/kaocha/watch_test.clj
@@ -87,3 +87,28 @@
                      "foo"
                      prefix)
         @out-str)))
+
+(deftest watch-test-do-not-trigger-on-dir-changes
+  (let [{:keys [config-file test-dir] :as m} (integration/test-dir-setup {})
+        config (-> (config/load-config config-file)
+                   (assoc-in [:kaocha/cli-options :config-file] (str config-file))
+                   (assoc-in [:kaocha/tests 0 :kaocha/source-paths] [])
+                   (assoc-in [:kaocha/tests 0 :kaocha/test-paths] [(str test-dir)]))
+        finish? (atom false)
+        q       (w/make-queue)
+        out-str (promise)]
+    (integration/spit-file m "tests.edn" (prn-str config))
+    (integration/spit-dir m "test/somedir")
+
+    (future (deliver out-str (util/with-test-out-str
+                               (t/with-test-out
+                                 (util/with-test-ctx
+                                   (w/run* config finish? q))))))
+
+    (Thread/sleep 100)
+    (w/qput q (clojure.java.io/file (.resolve (:dir m) "test/somedir")))
+    (Thread/sleep 100)
+    (reset! finish? true)
+    (w/qput q :finish)
+
+    (is (= "[]\n0 tests, 0 assertions, 0 failures.\n\n[watch] watching stopped.\n" @out-str))))


### PR DESCRIPTION
On OSX changing files will often also emit events on the containing directory,
causing excessive test runs while in --watch mode. This manifests as duplicate
test runs, but is especially visible when ignoring certain file patterns.

This commit adds a check for directories and ignores those events.