### PR TITLE
Partially fix watch test bug

### DIFF
--- a/test/unit/kaocha/watch_test.clj
+++ b/test/unit/kaocha/watch_test.clj
@@ -79,11 +79,12 @@
 
     (Thread/sleep 100)
     (integration/spit-file m (str "test/" prefix "/bar_test.clj") (str "(ns " prefix ".bar-test (:require [clojure.test :refer :all])) (deftest xxx-test (is (= :xxx :zzz)))"))
+    (w/qput q (.resolve (:dir m) (str "test/" prefix "/bar_test.clj")))
     (Thread/sleep 100)
     (reset! finish? true)
     (w/qput q :finish)
 
-    (is (str/replace "[(F)]\n\nFAIL in foo.bar-test/xxx-test (bar_test.clj:1)\nExpected:\n  :xxx\nActual:\n  -:xxx +:yyy\n1 tests, 1 assertions, 1 failures.\n\n[watch] Reloading #{foo.bar-test}\n[watch] Re-running failed tests #{:foo.bar-test/xxx-test}\n[(F)]\n\nFAIL in foo.bar-test/xxx-test (bar_test.clj:1)\nExpected:\n  :xxx\nActual:\n  -:xxx +:zzz\n1 tests, 1 assertions, 1 failures.\n\n[watch] watching stopped.\n"
-                     "foo"
-                     prefix)
-        @out-str)))
+    (is (= (str/replace "[(F)]\n\nFAIL in foo.bar-test/xxx-test (bar_test.clj:1)\nExpected:\n  :xxx\nActual:\n  -:xxx +:yyy\n1 tests, 1 assertions, 1 failures.\n\n[watch] Reloading #{foo.bar-test}\n[watch] Re-running failed tests #{:foo.bar-test/xxx-test}\n[(F)]\n\nFAIL in foo.bar-test/xxx-test (bar_test.clj:1)\nExpected:\n  :xxx\nActual:\n  -:xxx +:zzz\n1 tests, 1 assertions, 1 failures.\n\n[watch] watching stopped.\n"
+                      "foo"
+                      prefix)
+           @out-str))))


### PR DESCRIPTION
I discovered that the watch-test had an `(is a b)` type bug - it wasn't verifying its assertion. Kaocha can catch those, can't it? :)

Anyway, I added in the equals, and further discovered that the test wasn't producing the expected outcome. On my system (OSX) I needed to manually trigger an event to see the second run in the output. The test is still failing though, as I'm not seeing the `"Reloading #{foo.bar-test}"` part in my test run. I figured maybe you'd catch this more easily than me?