### PR TITLE
Add hierarchy tags and helpers to mark suites and groups

### DIFF
--- a/src/kaocha/hierarchy.clj
+++ b/src/kaocha/hierarchy.clj
@@ -77,6 +77,16 @@
 
 ;; Testable types
 
+(defn suite?
+  "Top level testables are called suites, e.g. a suite of clojure.test tests."
+  [testable]
+  (isa? (:kaocha.testable/type testable) :kaocha.testable.type/suite))
+
+(defn group?
+  "Intermediary testables are called groups, e.g. a namespace of tests."
+  [testable]
+  (isa? (:kaocha.testable/type testable) :kaocha.testable.type/group))
+
 (defn leaf?
   "This is a leaf in the tree of testables, i.e. it's an actual test with
   assertions, not just a container for tests.

--- a/src/kaocha/type/clojure/test.clj
+++ b/src/kaocha/type/clojure/test.clj
@@ -5,6 +5,7 @@
             [kaocha.type.ns :as type.ns]
             [kaocha.testable :as testable]
             [kaocha.classpath :as classpath]
+            [kaocha.hierarchy :as hierarchy]
             [kaocha.load :as load]
             [clojure.java.io :as io]
             [clojure.test :as t]))
@@ -30,3 +31,5 @@
 (s/def :kaocha/source-paths (s/coll-of string?))
 (s/def :kaocha/test-paths (s/coll-of string?))
 (s/def :kaocha/ns-patterns (s/coll-of string?))
+
+(hierarchy/derive! :kaocha.type/clojure.test :kaocha.testable.type/suite)

--- a/src/kaocha/type/ns.clj
+++ b/src/kaocha/type/ns.clj
@@ -3,6 +3,7 @@
   (:require [clojure.test :as t]
             [kaocha.core-ext :refer :all]
             [kaocha.testable :as testable]
+            [kaocha.hierarchy :as hierarchy]
             [clojure.spec.alpha :as s]
             [kaocha.type.var]
             [kaocha.output :as output]
@@ -88,3 +89,5 @@
 
 (s/def :kaocha.ns/name simple-symbol?)
 (s/def :kaocha.ns/ns   ns?)
+
+(hierarchy/derive! :kaocha.type/ns :kaocha.testable.type/group)

--- a/test/unit/kaocha/hierarchy_test.clj
+++ b/test/unit/kaocha/hierarchy_test.clj
@@ -1,0 +1,58 @@
+(ns kaocha.hierarchy-test
+  (:require [clojure.test :refer :all]
+            [kaocha.hierarchy :as h]))
+
+(require 'kaocha.type.clojure.test)
+
+(derive ::global-leaf :kaocha.testable.type/leaf)
+(derive ::global-group :kaocha.testable.type/group)
+(derive ::global-suite :kaocha.testable.type/suite)
+(h/derive! ::local-leaf :kaocha.testable.type/leaf)
+(h/derive! ::local-group :kaocha.testable.type/group)
+(h/derive! ::local-suite :kaocha.testable.type/suite)
+
+(deftest fail-type?-test
+  (is (h/fail-type? {:type :fail}))
+  (is (h/fail-type? {:type :error})))
+
+(deftest error-type?-test
+  (is (h/error-type? {:type :error})))
+
+(deftest pass-type?-test
+  (is (h/pass-type? {:type :pass})))
+
+(deftest known-key?-test
+  (is (h/known-key? {:type :pass}))
+  (is (h/known-key? {:type :fail}))
+  (is (h/known-key? {:type :error}))
+  (is (h/known-key? {:type :kaocha/known-key}))
+  (is (h/known-key? {:type :kaocha/deferred}))
+  (is (not (h/known-key? {:type :kaocha/foo}))))
+
+(derive ::global-deferred :kaocha/deferred)
+(h/derive! ::local-deferred :kaocha/deferred)
+
+(deftest deferred?-test
+  (is (h/deferred? {:type ::global-deferred}))
+  (is (h/deferred? {:type ::local-deferred})))
+
+(deftest pending?-test
+  (is (h/pending? {:type :kaocha/pending})))
+
+(deftest suite-test
+  (is (h/suite? {:kaocha.testable/type :kaocha.testable.type/suite}))
+  (is (h/suite? {:kaocha.testable/type :kaocha.type/clojure.test}))
+  (is (h/suite? {:kaocha.testable/type ::global-suite}))
+  (is (h/suite? {:kaocha.testable/type ::local-suite})))
+
+(deftest group-test
+  (is (h/group? {:kaocha.testable/type :kaocha.testable.type/group}))
+  (is (h/group? {:kaocha.testable/type :kaocha.type/ns}))
+  (is (h/group? {:kaocha.testable/type ::global-group}))
+  (is (h/group? {:kaocha.testable/type ::local-group})))
+
+(deftest leaf-test
+  (is (h/leaf? {:kaocha.testable/type :kaocha.testable.type/leaf}))
+  (is (h/leaf? {:kaocha.testable/type :kaocha.type/var}))
+  (is (h/leaf? {:kaocha.testable/type ::global-leaf}))
+  (is (h/leaf? {:kaocha.testable/type ::local-leaf})))


### PR DESCRIPTION
Top level testables are called test suites, bottom level ones are called leafs,
the ones in the middle are groups. Leafs were already getting marked in the
hierarchy, now groups and suites are too.