### PR TITLE
Suppressing warnings

### DIFF
--- a/src/kaocha/plugin/filter.clj
+++ b/src/kaocha/plugin/filter.clj
@@ -45,8 +45,9 @@
                          (testable/test-seq testable))
         focus-meta (set focus-meta)
         unused     (set/difference focus-meta used-meta)]
-    (doseq [u unused]
-      (output/warn "No tests found with metadata key " u ". Ignoring --focus-meta " u "."))
+    (when (:focus-meta-not-found (:kaocha/warnings testable) true)
+      (doseq [u unused]
+        (output/warn "No tests found with metadata key " u ". Ignoring --focus-meta " u ".")))
     (set/difference focus-meta unused)))
 
 (defn filter-testable [testable opts]

--- a/src/kaocha/testable.clj
+++ b/src/kaocha/testable.clj
@@ -63,7 +63,8 @@
   [testable]
   (load-type+validate testable)
   (doseq [path (:kaocha/test-paths testable)]
-    (when-not (.exists (io/file path))
+    (when (and (:test-path-does-not-exist (:kaocha/warnings testable) true)
+               (not (.exists (io/file path))))
       (output/warn "In :test-paths, no such file or directory: " path))
     (classpath/add-classpath path))
 


### PR DESCRIPTION
Hi @plexus !

Like we discussed in #40, I started looking at configuration options to suppress warnings. This is not a complete Pull Request, but I could use some feedback.

- Suppressing the `:focus-meta-not-found` warning works like this. 👍  

However, I was planning on adding flags for the other warnings as well:

- Suppressing the `:test-path-does-not-exist` warning only works if you add the configuration to the test suite, and not to the overall configuration map.

That's because the `testable` being passed in does not contain the configuration. How do you normally handle these cases? 

- Suppressing the `:deprecated-config-literal` seems to me like needless busywork. If you're able to add the suppressing flag to the config, just change to `#kaocha/v1` already. 😄 

Your thoughts on this are most welcome. 

Cheers!