### PR TITLE
Doc and default config

### DIFF
--- a/doc/05_running_kaocha_repl.md
+++ b/doc/05_running_kaocha_repl.md
@@ -90,6 +90,6 @@ When using CIDER this combines really well with
 
 ## Config and Test plan
 
-The `(kaocha.repl/config)` and `(kaocha.config/test-plan)` functions are very
+The `(kaocha.repl/config)` and `(kaocha.repl/test-plan)` functions are very
 useful when diagnosing issues, and can be helpful when developing plugins or
 test types.

--- a/resources/kaocha/default_config.edn
+++ b/resources/kaocha/default_config.edn
@@ -9,4 +9,4 @@
                       :kaocha/ns-patterns      ["-test$"]
                       :kaocha/source-paths     ["src"]
                       :kaocha/test-paths       ["test"]
-                      :kaocha.filter/skip-meta [:kaocha/skip]}]}}
+                      :kaocha.filter/skip-meta [:kaocha/skip]}]}


### PR DESCRIPTION
Minor, unsolicited fixes
- Edit doc ch5: `test-plan` not found in `config` ns
- Remove extra closing curly in default config 