### PR TITLE
Improve quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,17 +145,21 @@ of the project to configure actual test and source paths, and optionally set a
 reporter or load plugins (cf. Configuration in the
 [documentation](https://cljdoc.org/d/lambdaisland/kaocha/)).
 
-Example `test.edn`:
+
+Example of a catch-all `test.edn` config file (should run all
+tests found in `src/` and `/test`, in any namespace).
 ``` clojure
 #kaocha/v1
-{:tests [{:id :unit
-          :test-paths ["test/unit"]
-          :source-paths ["src-clj"]
-          :ns-patterns ["-test$"]}]
- ;; :reporter kaocha.report.progress/progress
- ;; :plugins [:profiling :notifier]
+#kaocha/v1
+{:tests [{:id          :unit
+          :test-paths  ["test" "src"]
+          :ns-patterns [".*"]}]}
+          ;; :reporter kaocha.report.progress/progress
+          ;; :plugins [:profiling :notifier]
  }
 ```
+Warning: this is not an optimal configuration. To avoid extra churn, you should
+try and target only folders and namespaces that actually contain tests.
 
 Run your tests
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ This is no replacement for reading the docs, but if you're particularly
 impatient to try it out, or if you already know Kaocha and need a quick
 reference how to set up a new project, then this guide is for you.
 
-
-
 ### Clojure CLI (tools.deps)
 
 Add Kaocha as a dependency, preferably under an alias.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ This is no replacement for reading the docs, but if you're particularly
 impatient to try it out, or if you already know Kaocha and need a quick
 reference how to set up a new project, then this guide is for you.
 
+
+
 ### Clojure CLI (tools.deps)
 
 Add Kaocha as a dependency, preferably under an alias.
@@ -132,14 +134,25 @@ chmod +x bin/kaocha
 
 ### All tools
 
-Add a `tests.edn` at the root of the project, add a first test suite with test
-and source paths. Optionally set a reporter or load plugins.
+By default, Kaocha assumes that:
+- source files are in the `src/` folder,
+- tests files are in the `test/` folder,
+- all test namespaces _names_ end with `-test`
+(eg. `my-project.core-test`).
+Also, the default test suite id is `:unit` (just `unit` on the command line).
 
+If your tests don't seem to run (outcome is `0 tests, 0 assertions, 0 failures`)
+you may need to write up your own configuration: add a `tests.edn` at the root
+of the project to configure actual test and source paths, and optionally set a
+reporter or load plugins (cf. Configuration in the
+[documentation](https://cljdoc.org/d/lambdaisland/kaocha/)).
+
+Example `test.edn`:
 ``` clojure
 #kaocha/v1
 {:tests [{:id :unit
           :test-paths ["test/unit"]
-          :source-paths ["src"]
+          :source-paths ["src-clj"]
           :ns-patterns ["-test$"]}]
  ;; :reporter kaocha.report.progress/progress
  ;; :plugins [:profiling :notifier]

--- a/doc/03_configuration.md
+++ b/doc/03_configuration.md
@@ -110,17 +110,20 @@ the testing library included with Clojure itself.
 
 It takes the following configuration options.
 
-- `:ns-patterns`: vector of patterns, these are strings that get intepreted as
-  regular expressions. If one of them matches the namespace name then this
-  namespace is considered a test namespace, and will get loaded as part of
-  Kaocha's "load" step. Patterns can be given as actual regex types or as
-  strings. Defaults to `["-test$"]`
+- `:ns-patterns`: vector of patterns. Patterns are _not_ regexes, they are
+  _strings_ that get intepreted as regular expressions (do not prepend with
+  `#`). If one of them matches the namespace name then this namespace is
+  considered a test namespace, and will get loaded as part of Kaocha's "load"
+  step. 
+  Defaults to `["-test$"]`
 - `:source-paths`: vector of paths containing source code under test. This
   is used to determine which files to watch for changes, and can be used by
-  plugins e.g. when doing code coverage analyis. Defaults to `["src"]`
+  plugins e.g. when doing code coverage analyis.
+  Defaults to `["src"]`
 - `:test-paths`: vector of paths containing tests. These paths are added to the
   JVM classpath prior to executing this suite, and they are searched for
   namespaces to load.
+  Defaults to `["test"]`
 
 ## Plugins
 

--- a/doc/05_running_kaocha_repl.md
+++ b/doc/05_running_kaocha_repl.md
@@ -90,6 +90,6 @@ When using CIDER this combines really well with
 
 ## Config and Test plan
 
-The `(kaocha.repl/config)` and `(kaocha.config/test-plan)` functions are very
+The `(kaocha.repl/config)` and `(kaocha.repl/test-plan)` functions are very
 useful when diagnosing issues, and can be helpful when developing plugins or
 test types.

--- a/resources/kaocha/default_config.edn
+++ b/resources/kaocha/default_config.edn
@@ -9,4 +9,4 @@
                       :kaocha/ns-patterns      ["-test$"]
                       :kaocha/source-paths     ["src"]
                       :kaocha/test-paths       ["test"]
-                      :kaocha.filter/skip-meta [:kaocha/skip]}]}}
+                      :kaocha.filter/skip-meta [:kaocha/skip]}]}

--- a/src/kaocha/testable.clj
+++ b/src/kaocha/testable.clj
@@ -102,6 +102,9 @@
   Also performs validation, and lazy loading of the testable type's
   implementation."
   [testable test-plan]
+  (when (empty? (:kaocha.test-plan/tests testable))
+    (output/warn (str "No tests were found, make sure :test-paths and " 
+                      ":ns-patterns are configured correctly in tests.edn.")))
   (load-type+validate testable)
   (binding [*current-testable* testable]
     (let [run (plugin/run-hook :kaocha.hooks/wrap-run -run test-plan)


### PR DESCRIPTION
#60 "Default ns-pattern "-test$" is confusing"
#34 "Provide a warning when no tests are found"

1. Kaocha seems to be running okay out of the box without the need for a `test.edn` config file, provided some conventions are being followed. Make this the most straightforward option to get started. 

2. While the defaults make sense, a catch-all configuration example would help to get up and running quickly on existing projects, with a due statement that it is suboptimal.

3. When no tests are found, a warning should be printed, with the most obvious corrective actions briefly mentioned.