### PR TITLE
Check for libraries versions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,8 @@
   orchestra                    {:mvn/version "2018.12.06-2"}
   aero                         {:mvn/version "1.1.3"}
   progrock                     {:mvn/version "0.1.2"}
-  meta-merge                   {:mvn/version "1.0.0"}}
+  meta-merge                   {:mvn/version "1.0.0"}
+  andreacrotti/semver          {:mvn/version "0.2.2"}}
 
  :aliases
  {:test

--- a/src/kaocha/versions.clj
+++ b/src/kaocha/versions.clj
@@ -1,0 +1,23 @@
+(ns kaocha.versions
+  (:require [clojure.java.io :as io]
+            [semver.core :as semver])
+  (:import (java.util Properties)))
+
+(defn get-version
+  [dep]
+  (let [path (str "META-INF/maven/" (or (namespace dep) (name dep))
+                  "/" (name dep) "/pom.properties")
+        props (io/resource path)]
+    (when props
+      (with-open [stream (io/input-stream props)]
+        (let [props (doto (Properties.) (.load stream))]
+          (.getProperty props "version"))))))
+
+(def min-required-versions
+  {'org.clojure/tools.cli "0.4.0"})
+
+(defn check-versions!
+  []
+  (doseq [[dep version] min-required-versions]
+    (when-not (semver/newer? (get-version dep) version)
+      (throw (Exception. (format "Library %s is too old please upgrade to at least %s" (str dep) version))))))


### PR DESCRIPTION
This is a simple way to blow up more noisily when a library version doesn't satisfy the needs of Kaocha (the org.clojure/tools.cli example).

Is not plugged in anywhere atm but for example setting a version higher than the one need would give a similar error at the moment.

![screen shot 2019-02-28 at 11 47 06](https://user-images.githubusercontent.com/53640/53564431-c92a6f00-3b4e-11e9-8b6c-57ed113341c4.png)
