### PR TITLE
Make scripts more portable, replacing  `/bin/bash` with `/usr/bin/env bash`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Add a binstub called `bin/kaocha`
 
 ```
 mkdir -p bin
-echo '#!/bin/bash' > bin/kaocha
+echo '#!/usr/bin/env bash' > bin/kaocha
 echo 'clojure -A:test -m kaocha.runner "$@"' >> bin/kaocha
 chmod +x bin/kaocha
 ```
@@ -104,7 +104,7 @@ Add a binstub called `bin/kaocha`
 
 ``` shell
 mkdir -p bin
-echo '#!/bin/bash' > bin/kaocha
+echo '#!/usr/bin/env bash' > bin/kaocha
 echo 'lein kaocha "$@"' >> bin/kaocha
 chmod +x bin/kaocha
 ```
@@ -125,7 +125,7 @@ Add a binstub called `bin/kaocha`
 
 ``` bash
 mkdir -p bin
-echo '#!/bin/bash' > bin/kaocha
+echo '#!/usr/bin/env bash' > bin/kaocha
 echo 'boot kaocha "$@"' >> bin/kaocha
 chmod +x bin/kaocha
 ```

--- a/bin/check_feature
+++ b/bin/check_feature
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 bin/run_feature "$@" 1>/tmp/kaocha_actual_out 2>/tmp/kaocha_actual_err
 

--- a/bin/check_features
+++ b/bin/check_features
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RESULT=0
 

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 clojure -A:dev:test -m kaocha.runner "$@"

--- a/bin/prep_release
+++ b/bin/prep_release
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function echo_info() {
    echo -en "[\033[0;32mINFO\033[0m] "

--- a/bin/release
+++ b/bin/release
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/bin/run_feature
+++ b/bin/run_feature
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 bin/kaocha --config-file features/$1/tests.edn `cat features/$1/args` "${@:2}"

--- a/bin/update_feature
+++ b/bin/update_feature
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 bin/run_feature "$@" 1>features/$1/out 2>features/$1/err
 echo $? > features/$1/exit

--- a/doc/02_installing.md
+++ b/doc/02_installing.md
@@ -37,7 +37,7 @@ namespace. This is what `bin/kaocha` by default looks like. Make sure to add
 `"$@"` so that any arguments to `bin/kaocha` are passed on to `kaocha.runner`.
 
 ``` shell
-#!/bin/bash
+#!/usr/bin/env bash
 
 clojure -A:test -m kaocha.runner "$@"
 ```
@@ -52,7 +52,7 @@ This script provides a useful place to encode extra flags or setup that is
 needed in order for tests to run correctly.
 
 ``` shell
-#!/bin/bash
+#!/usr/bin/env bash
 
 . secrets.env
 clojure -J-Xmx512m -A:dev:test -m kaocha.runner --config-file test/tests.edn "$@"
@@ -94,7 +94,7 @@ projects. The rest of the documentation assumes you can invoke Kaocha with
 `bin/kaocha`.
 
 ``` shell
-#!/bin/bash
+#!/usr/bin/env bash
 
 lein kaocha "$@"
 ```


### PR DESCRIPTION
The path `/bin/bash` doesn't exist in  some unix systems (like [NixOS](https://nixos.org/), which I use).
In general it's more portable to use `/usr/bin/env bash` instead of `/bin/bash`, see https://en.wikipedia.org/wiki/Shebang_(Unix)#Portability

It's just a suggestion, but I thought it would be better to offer the suggestion with a PR

