### PR TITLE
Fix option docs for --no-capture-output

### DIFF
--- a/doc/04_running_kaocha_cli.md
+++ b/doc/04_running_kaocha_cli.md
@@ -86,7 +86,7 @@ By default Kaocha will capture any output that occurs on stdout or stderr during
 a test run. Only when a test fails is the captured output printed as part of the
 test result summary. This is generally what you want, since this way tests that
 pass don't generate distracting noise. If you do want all the output as it
-occurs, use `--no-capture`.
+occurs, use `--no-capture-output`.
 
 ## Debug information
 


### PR DESCRIPTION
The correct option is `--no-capture-output`, not `--no-capture`