### PR TITLE
Add type hints to eliminate reflection warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Added
 
+- Type hints to eliminate reflection warnings.
+
 ## Fixed
 
 ## Changed

--- a/src/kaocha/classpath.clj
+++ b/src/kaocha/classpath.clj
@@ -24,7 +24,7 @@
    (classloader-hierarchy (deref clojure.lang.Compiler/LOADER)))
   ([tip]
    (->> tip
-        (iterate #(.getParent %))
+        (iterate #(.getParent ^ClassLoader %))
         (take-while boolean))))
 
 (defn- modifiable-classloader?

--- a/src/kaocha/core_ext.clj
+++ b/src/kaocha/core_ext.clj
@@ -19,10 +19,10 @@
   (instance? clojure.lang.Namespace x))
 
 (defn file? [x]
-  (and (instance? java.io.File x) (.isFile x)))
+  (and (instance? java.io.File x) (.isFile ^java.io.File x)))
 
 (defn directory? [x]
-  (and (instance? java.io.File x) (.isDirectory x)))
+  (and (instance? java.io.File x) (.isDirectory ^java.io.File x)))
 
 (defn path? [x]
   (instance? java.nio.file.Path x))

--- a/src/kaocha/monkey_patch.clj
+++ b/src/kaocha/monkey_patch.clj
@@ -37,9 +37,9 @@
                            :kaocha/test-plan testable/*test-plan*} m)
         m          (plugin/run-hook :kaocha.hooks/pre-report m)
         test-fn    (:kaocha.var/test (:kaocha/testable m))
-        stacktrace (.getStackTrace (if (exception? (:actual m))
-                                     (:actual m)
-                                     (Thread/currentThread)))
+        stacktrace (if (exception? (:actual m))
+                     (.getStackTrace ^Throwable (:actual m))
+                     (.getStackTrace ^Thread (Thread/currentThread)))
         file-and-line
         (or testable/*test-location*
             (stacktrace-file-and-line (drop-while

--- a/src/kaocha/plugin/capture_output.clj
+++ b/src/kaocha/plugin/capture_output.clj
@@ -13,7 +13,7 @@
 (defn make-buffer []
   (ByteArrayOutputStream.))
 
-(defn read-buffer [buffer]
+(defn read-buffer [^ByteArrayOutputStream buffer]
   (when buffer
     (-> buffer (.toByteArray) (String.))))
 
@@ -35,10 +35,10 @@
     (write
       ([data]
        (if (instance? Integer data)
-         (doto-capture-buffer #(.write % ^int data))
-         (doto-capture-buffer #(.write % ^bytes data 0 (alength ^bytes data)))))
+         (doto-capture-buffer #(.write ^OutputStream % ^int data))
+         (doto-capture-buffer #(.write ^OutputStream % ^bytes data 0 (alength ^bytes data)))))
       ([data off len]
-       (doto-capture-buffer #(.write % data off len))))))
+       (doto-capture-buffer #(.write ^OutputStream % data off len))))))
 
 (defn init-capture []
   (let [old-out             System/out

--- a/src/kaocha/stacktrace.clj
+++ b/src/kaocha/stacktrace.clj
@@ -11,7 +11,7 @@
                                      "kaocha.monkey_patch"])
 
 (defn elide-element? [e]
-  (some #(str/starts-with? (.getClassName e) %) *stacktrace-filters*))
+  (some #(str/starts-with? (.getClassName ^StackTraceElement e) %) *stacktrace-filters*))
 
 (defn print-stack-trace
   "Prints a Clojure-oriented stack trace of tr, a Throwable.
@@ -52,6 +52,6 @@
    (print-cause-trace tr nil))
   ([tr n]
    (print-stack-trace tr n)
-   (when-let [cause (.getCause tr)]
-     (print "Caused by: " )
+   (when-let [cause (.getCause ^Throwable tr)]
+     (print "Caused by: ")
      (recur cause n))))


### PR DESCRIPTION
Hey folks, thank you for the Kaocha! 
I'm running with with `*warn-on-reflection*` set as `true` and you may found useful to have these type hints as well.