### PR TITLE
Fix --watch without tests.edn (for real this time)

### DIFF
--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -101,9 +101,8 @@
         -2)
 
       (:kaocha/watch? config)
-      (do
-        ((jit kaocha.watch/run) config)
-        @(promise))
+      (let [[exit-code finish!] ((jit kaocha.watch/run) config)]
+        @exit-code)
 
       (:print-result options)
       (let [result (api/run (assoc config :kaocha/reporter []))


### PR DESCRIPTION
Also make sure the process exits with an exit code when this kind of exception
occurs (rather than continuing to block forever).

ping @WhittlesJr