### PR TITLE
Progress reporter no longer occludes syntax errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Fixed
 
+- The `kaocha.report.progress/progress` progress bar reporter now allows the
+  appropriate exception to be reported when there is a syntax error in Clojure
+  source code. Was formerly throwing NullPointerException.
+
 ## Changed
 
 # 0.0-529 (2019-07-04 / 975bbc6)

--- a/fixtures/e-tests/eee/bad_code_test.clj
+++ b/fixtures/e-tests/eee/bad_code_test.clj
@@ -1,0 +1,7 @@
+(ns eee.bad-code-test
+  (:require  [clojure.test :refer :all]))
+
+;; (def oops-iam-commented-out "oops")
+
+(deftest test-1
+  (is (= "oops" oops-iam-commented-out)))

--- a/fixtures/with_compile_error.edn
+++ b/fixtures/with_compile_error.edn
@@ -1,0 +1,5 @@
+#kaocha/v1
+{:tests [{:id                  :bad-code
+          :test-paths          ["fixtures/e-tests"]
+          :ns-patterns         [""]
+          :kaocha.filter/focus [eee.bad-code-test]}]}

--- a/src/kaocha/report/progress.clj
+++ b/src/kaocha/report/progress.clj
@@ -59,7 +59,8 @@
   (print-bar))
 
 (defmethod progress :error [m]
-  (swap! bar assoc :failed? true)
-  (print-bar))
+  (when @bar
+    (swap! bar assoc :failed? true)
+    (print-bar)))
 
 (def report [progress report/result])


### PR DESCRIPTION
When clojure code contained a syntax error, the progress reporter would suffer
a NullPointerException which occluded the syntax error exception.

This happened because the kaocha.report.progress :error method was being called
before the :begin-test-suite method wherein the progress bar is created.

Although I did not create automated tests to verify my fix, I did add some
fixture code to manually exercise the problem which I ran prior to and after
my fix via:
```
./bin/kaocha --config-file fixtures/with_compile_error.edn \
  --reporter kaocha.report.progress/report
```
Fixes #87