### PR TITLE
Consolidate kaocha.hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Unreleased
 
-## Added
-
-## Fixed
-
 ## Changed
+
+- Consolidate `kaocha.hierarchy`, so it can be used for kaocha-cljs
 
 # 0.0-529 (2019-07-04 / 975bbc6)
 

--- a/src/kaocha/hierarchy.clj
+++ b/src/kaocha/hierarchy.clj
@@ -6,8 +6,7 @@
 (defn derive!
   "Add a parent/child relationship to kaocha's keyword hierarchy."
   [tag parent]
-  #?(:clj (alter-var-root #'hierarchy derive tag parent)
-     :cljs (set! hierarchy (derive hierarchy tag parent))))
+  (alter-var-root #'hierarchy derive tag parent))
 
 (derive! :fail :kaocha/fail-type)
 (derive! :error :kaocha/fail-type)

--- a/src/kaocha/hierarchy.cljc
+++ b/src/kaocha/hierarchy.cljc
@@ -6,7 +6,8 @@
 (defn derive!
   "Add a parent/child relationship to kaocha's keyword hierarchy."
   [tag parent]
-  (alter-var-root #'hierarchy derive tag parent))
+  #?(:clj (alter-var-root #'hierarchy derive tag parent)
+     :cljs (set! hierarchy (derive hierarchy tag parent))))
 
 (derive! :fail :kaocha/fail-type)
 (derive! :error :kaocha/fail-type)
@@ -43,10 +44,28 @@
 
 (derive! :kaocha/deferred :kaocha/known-key)
 
+(derive! :kaocha.report/one-arg-eql :kaocha/known-key)
+(derive! :kaocha.report/one-arg-eql :kaocha/fail-type)
+
+(derive! :kaocha.type.var/zero-assertions :kaocha/known-key)
+(derive! :kaocha.type.var/zero-assertions :kaocha/fail-type)
+
+;; Older versions of Matcher-combinators
+(derive! :mismatch :kaocha/fail-type)
+(derive! :mismatch :kaocha/known-key)
+
+(derive! :matcher-combinators/mismatch :kaocha/fail-type)
+(derive! :matcher-combinators/mismatch :kaocha/known-key)
+
+;; Extra keys used by ClojureScript
+(derive! :begin-run-tests :kaocha/known-key)
+(derive! :end-run-tests :kaocha/known-key)
+(derive! :begin-test-all-vars :kaocha/known-key)
+(derive! :end-test-all-vars :kaocha/known-key)
+
 (defn isa? [tag parent]
   (or (clojure.core/isa? tag parent)
       (clojure.core/isa? hierarchy tag parent)))
-
 
 ;; Test event types
 

--- a/src/kaocha/matcher_combinators.clj
+++ b/src/kaocha/matcher_combinators.clj
@@ -9,12 +9,6 @@
             [fipp.engine :as fipp]
             [puget.color :as color]))
 
-(hierarchy/derive! :mismatch :kaocha/fail-type)
-(hierarchy/derive! :mismatch :kaocha/known-key)
-
-(hierarchy/derive! :matcher-combinators/mismatch :kaocha/fail-type)
-(hierarchy/derive! :matcher-combinators/mismatch :kaocha/known-key)
-
 (def print-handlers {'matcher_combinators.model.Mismatch
                      (fn [printer expr]
                        (printer/print-mismatch printer {:- (:expected expr)

--- a/src/kaocha/report.clj
+++ b/src/kaocha/report.clj
@@ -237,7 +237,6 @@
                    :actual '~form})
     (t/assert-predicate msg form)))
 
-(hierarchy/derive! ::one-arg-eql :kaocha/fail-type)
 
 (defmethod print-expr '= [m]
   (let [printer (output/printer)]

--- a/src/kaocha/type/var.clj
+++ b/src/kaocha/type/var.clj
@@ -10,9 +10,6 @@
             [clojure.string :as str])
   (:import [clojure.lang Var]))
 
-(hierarchy/derive! ::zero-assertions :kaocha/known-key)
-(hierarchy/derive! ::zero-assertions :kaocha/fail-type)
-
 (defmethod report/fail-summary ::zero-assertions [{:keys [testing-contexts testing-vars] :as m}]
   (println "\nFAIL in" (report/testing-vars-str m))
   (when (seq testing-contexts)
@@ -33,7 +30,6 @@
           (test)
           (catch clojure.lang.ExceptionInfo e
             (when-not (:kaocha/fail-fast (ex-data e))
-
               (report/report-exception e)))
           (catch Throwable e (report/report-exception e))))
       (let [{::result/keys [pass error fail pending] :as result} (type/report-count)]


### PR DESCRIPTION
This is needed for the upcoming matcher-combinator support in ClojureScript.