### PR TITLE
Fix documentation for progress reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ tests found in `src/` and `/test`, in any namespace).
 {:tests [{:id          :unit
           :test-paths  ["test" "src"]
           :ns-patterns [".*"]}]}
-          ;; :reporter kaocha.report.progress/progress
+          ;; :reporter kaocha.report.progress/report
           ;; :plugins [:kaocha.plugin/profiling :kaocha.plugin/notifier]
  }
 ```

--- a/doc/03_configuration.md
+++ b/doc/03_configuration.md
@@ -217,10 +217,10 @@ kaocha.type.var-test
       early exit - exception ERROR
 ```
 
-### `kaocha.report.progress/progress`
+### `kaocha.report.progress/report`
 
-CLI: `--reporter kaocha.report.progress/progress`
-Config: `{:kaocha/reporter [kaocha.report.progress/progress]}`
+CLI: `--reporter kaocha.report.progress/report`
+Config: `{:kaocha/reporter [kaocha.report.progress/report]}`
 
 Prints a separate progress bar for each test suite, with progress percentage,
 and the completed/total number of test vars.

--- a/doc/04_running_kaocha_cli.md
+++ b/doc/04_running_kaocha_cli.md
@@ -39,7 +39,7 @@ output.
 For example, to see a colorful progress bar, use
 
 ``` shell
-bin/kaocha --reporter kaocha.report.progress/progress
+bin/kaocha --reporter kaocha.report.progress/report
 ```
 
 Plugins in the `kaocha.plugin` namespace, and reporters in the `kaocha.report`


### PR DESCRIPTION
kaocha.report.progress/progress only shows the bar,
kaocha.report.progress/report also shows the actual failures, so it's
probably what people want

Could also consider renaming `progress/progress` -> `progress/progress*`, `progress/report` -> `progress/progress`.