### PR TITLE
Introduce a meta-merge aero tag

### DIFF
--- a/doc/03_configuration.md
+++ b/doc/03_configuration.md
@@ -53,6 +53,36 @@ used in `#kaocha/v1 {}`, rather than using fully qualified keywords.
 Configuration is read with [Aero](https://github.com/juxt/aero), meaning you
 have access to reader literals like `#env`, `#merge`, `#ref`, and `#include`.
 
+Additionally kaocha supports an extra `#k/meta-merge` reader tag, that
+works similarly to aero's `#merge` but will merge a whole subtree with
+the semantics of
+[meta-merge](https://github.com/weavejester/meta-merge).  This is
+particularly useful for configuring a cascade of includes that
+selectively augment and override a base configuration.  e.g. imagine a
+base tests.edn file with a `#k/meta-merge` and an `#include`:
+
+```
+#kaocha/v1
+#k/meta-merge [{:tests [{:id         :unit
+              :test-paths ["test/unit"]}
+             {:id         :features
+             :test-paths ["test/features"]}]
+             :kaocha/plugins [:kaocha.plugin.some.required/plugin
+                              ,,,]
+             }
+
+        #include "tests.user.edn"]
+```
+
+This setup would allow developers to maintain their own private
+`tests.user.edn` file and augment the above configuration with for example
+their own set of plugins such as the notifier etc.
+
+The primary advantage to using the `#k/meta-merge` tag over aero's
+`#merge` is that meta-merge will do a deep merge of the tree; meaning
+developers can more easily inherit changes to the base configuration.
+
+
 ## Test suites
 
 Test suites are a first class concept in Kaocha. This encourages testing at

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -6,13 +6,16 @@
             [slingshot.slingshot :refer [throw+]]
             [meta-merge.core :refer [meta-merge]]))
 
+(defmethod aero/reader 'k/meta-merge [opts _tag value]
+  (apply meta-merge value))
+
+(defn default-config []
+  (aero/read-config (io/resource "kaocha/default_config.edn")))
+
 (defn- rename-key [m old-key new-key]
   (if (contains? m old-key)
     (assoc (dissoc m old-key) new-key (get m old-key))
     m))
-
-(defn default-config []
-  (aero/read-config (io/resource "kaocha/default_config.edn")))
 
 (defn replace-by-default [config k]
   (if-let [v (get config k)]


### PR DESCRIPTION
Fixes #127 

I suspect the diff coverage fell beneath the threshold because I also moved a function down within the file.

There are no tests for this feature.  I can add some but not sure how best to test it without testing meta-merge.  Could maybe just test a file the meta-merge tag in it doesn't fail a call to read?