### PR TITLE
removing requirement on bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Add a binstub called `bin/kaocha`
 
 ```
 mkdir -p bin
-echo '#!/usr/bin/env bash' > bin/kaocha
+echo '#!/usr/bin/env sh' > bin/kaocha
 echo 'clojure -A:test -m kaocha.runner "$@"' >> bin/kaocha
 chmod +x bin/kaocha
 ```
@@ -117,7 +117,7 @@ Add a binstub called `bin/kaocha`
 
 ``` shell
 mkdir -p bin
-echo '#!/usr/bin/env bash' > bin/kaocha
+echo '#!/usr/bin/env sh' > bin/kaocha
 echo 'lein kaocha "$@"' >> bin/kaocha
 chmod +x bin/kaocha
 ```
@@ -138,7 +138,7 @@ Add a binstub called `bin/kaocha`
 
 ``` bash
 mkdir -p bin
-echo '#!/usr/bin/env bash' > bin/kaocha
+echo '#!/usr/bin/env sh' > bin/kaocha
 echo 'boot kaocha "$@"' >> bin/kaocha
 chmod +x bin/kaocha
 ```


### PR DESCRIPTION
Pretty sure `$@` is POSIX shell compliant, not a bash-ism.