### PR TITLE
Apply focus/skip/-meta in two stages, first test suite, then CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Unreleased
 
-## Added
-
-## Fixed
-
 ## Changed
+
+- Breaking change! Focus/skip options are now applied in two passes, once for
+  options in `tests.edn`, once for command-line/REPL options. The result is that
+  command line options can only narrow the set of tests to be run. (thanks
+  [@otwieracz](https://github.com/otwieracz))
 
 # 0.0-573 (2020-01-13 / 156d084)
 


### PR DESCRIPTION
Instead of processing all focus/meta directives at once, first process the test
plan to skip tests based on test-suite level config in tests.edn, then do a
second pass based on CLI args, so that CLI args can only narrow down the
original selection.

Co-authored-by: Slawomir Gonez

Closes #126 

