### PR TITLE
Fix #133: cannot set dynamic variables in --watch mode

### DIFF
--- a/src/kaocha/watch.clj
+++ b/src/kaocha/watch.clj
@@ -222,7 +222,7 @@ errors as test errors."
         finish!   (fn []
                     (reset! finish? true)
                     (qput q :finish))
-        exit-code (future
+        bfn       (bound-fn []
                     (try
                       (run* config finish? q)
                       0
@@ -230,5 +230,6 @@ errors as test errors."
                         (st/print-cause-trace t)
                         -3)
                       (finally
-                        (println "[watch] watching stopped."))))]
+                        (println "[watch] watching stopped."))))
+        exit-code (future (bfn))]
     [exit-code finish!]))


### PR DESCRIPTION
Closes #133 

Rebinding the current set of dynamic variables in the `future` allows dynamic variables to be rebound in tests.