### PR TITLE
Report bad ns form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # Unreleased
 
-## Added
-
 ## Fixed
 
-## Changed
+- Namespaces where the ns form can not be read by tools.readers are now reported
+  as a test failure, rather than being quietly ignored.
 
 # 0.0-597 (2020-03-10 / 746943b)
 

--- a/bin/prep_release
+++ b/bin/prep_release
@@ -59,7 +59,7 @@ RELEASE_NOTES=$(mktemp /tmp/${PROJECT}_${VERSION}_release_notes_XXXXXXXXXX.md)
 } |ed $RELEASE_NOTES
 
 git add -A
-git commit -m `cat $RELEASE_NOTES`
+git commit -m "$(cat $RELEASE_NOTES)"
 git tag v$VERSION
 
 git show v$VERSION

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
  {org.clojure/clojure          {:mvn/version "1.10.1"}
   org.clojure/spec.alpha       {:mvn/version "0.2.176"}
   org.clojure/tools.cli        {:mvn/version "0.4.2"}
-  lambdaisland/tools.namespace {:mvn/version "0.0-234"}
+  lambdaisland/tools.namespace {:mvn/version "0.0-237"}
   lambdaisland/deep-diff       {:mvn/version "0.0-47"}
   org.tcrawley/dynapath        {:mvn/version "1.1.0"}
   slingshot                    {:mvn/version "0.12.2"}

--- a/src/kaocha/load.clj
+++ b/src/kaocha/load.clj
@@ -7,25 +7,43 @@
             [lambdaisland.tools.namespace.find :as ctn-find]
             [kaocha.output :as output]))
 
+(set! *warn-on-reflection* true)
+
 (def clj ctn-find/clj)
 (def cljs ctn-find/cljs)
 
-(defn ns-match? [ns-patterns ns-sym]
-  (some #(re-find % (name ns-sym)) ns-patterns))
+(defn ns-match? [ns-patterns ns-sym-or-error]
+  (or (ctn-find/reader-exception? ns-sym-or-error)
+      (some #(re-find % (name ns-sym-or-error)) ns-patterns)))
 
 (defn find-test-nss [test-paths ns-patterns & [platform]]
   (sequence (comp
              (map io/file)
-             (map #(ctn-find/find-namespaces-in-dir % platform))
-             cat
+             (mapcat #(ctn-find/find-namespaces-in-dir % platform))
              (filter (partial ns-match? ns-patterns)))
             test-paths))
+
+(defn load-error-testable [file exception]
+  {::testable/type               :kaocha.type/ns
+   ::testable/id                 (keyword (str file))
+   ::testable/desc               (str "ns form could not be read in " file)
+   ::testable/load-error         exception
+   ::testable/load-error-file    (str file)
+   ::testable/load-error-line    1
+   ::testable/load-error-message (str "Failed reading ns form in " file "\n"
+                                      "Caused by: " (.getMessage ^Throwable exception))
+   :kaocha.ns/name               'kaocha.load-error})
 
 (defn load-test-namespaces [testable ns-testable-fn & [platform]]
   (let [test-paths  (:kaocha/test-paths testable)
         ns-patterns (map regex (:kaocha/ns-patterns testable))
         ns-names    (find-test-nss test-paths ns-patterns platform)
-        testables   (map ns-testable-fn ns-names)]
+        testables   (map (fn [sym-or-error]
+                           (if (ctn-find/reader-exception? sym-or-error)
+                             (let [[_ file exception] sym-or-error]
+                               (load-error-testable file exception))
+                             (ns-testable-fn sym-or-error)))
+                         ns-names)]
     (assoc testable
            :kaocha.test-plan/tests
            (testable/load-testables testables))))

--- a/src/kaocha/report.clj
+++ b/src/kaocha/report.clj
@@ -294,7 +294,7 @@
     (println message))
   (if-let [expr (::printed-expression m)]
     (print expr)
-    (let [actual (:actual m)]
+    (when-let [actual (:actual m)]
       (print "Exception: ")
       (if (throwable? actual)
         (stacktrace/print-cause-trace actual t/*stack-trace-depth*)


### PR DESCRIPTION
When a test namespace has an ns form that can't be read by tools.namespace, then
tools.namespace would simply pretend that ns did not exist, and we would happily
carry on from there. This is problematic, people should be notified when we are
unable to load a test file.

We've updated our fork of tools.namespace to return these errors including the
file name context, which we then use to turn them into load errors.

When a load error is encountered the test is not run, but it's reported as an
error through the configured reporter. Any sibling tests are skipped.

Closes #135 