### PR TITLE
Add orchestra and require-ns plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Added
 
+- An Orchestra plugin `:kaocha.plugin/orchestra` for instrumenting
+  functions specs with [Orchestra](https://github.com/jeaye/orchestra)
+- A Preloads plugin `:kaocha.plugin/preloads` for requiring namespaces
+  before Kaocha loads test suites. This is useful for requiring spec
+  namespaces or other side-effecting namespaces that are not required
+  by test code.
+
 ## Fixed
 
 - Fixed an issue where plugin names where not correctly normalized before

--- a/src/kaocha/plugin/orchestra.clj
+++ b/src/kaocha/plugin/orchestra.clj
@@ -1,0 +1,16 @@
+(ns kaocha.plugin.orchestra
+  (:require [kaocha.plugin :refer [defplugin]]
+            [orchestra.spec.test :as orchestra]))
+
+(defplugin kaocha.plugin/orchestra
+  (post-load [test-plan]
+     ;; Instrument specs after all of the test namespaces have been loaded
+     (orchestra/instrument)
+     test-plan)
+
+  (post-run [result]
+     ;; Unstrument specs after tests have run. This isn't so important
+     ;; for CLI testing as the process will exit shortly after the post-run
+     ;; step, but is helpful for running Kaocha tests from the REPL.
+     (orchestra/unstrument)
+     result))

--- a/src/kaocha/plugin/preloads.clj
+++ b/src/kaocha/plugin/preloads.clj
@@ -1,0 +1,8 @@
+(ns kaocha.plugin.preloads
+  (:require [kaocha.plugin :refer [defplugin]]))
+
+(defplugin kaocha.plugin/preloads
+  (pre-load [config]
+    (when-let [ns-names (::ns-names config)]
+      (apply require ns-names))
+    config))

--- a/test/features/plugins/orchestra_plugin.feature
+++ b/test/features/plugins/orchestra_plugin.feature
@@ -1,0 +1,54 @@
+Plugin: Orchestra (spec instrumentation)
+
+  You can enable spec instrumentation of your functions before running
+  tests with the `:kaocha.plugin/orchestra` plugin. This uses the
+  [Orchestra](https://github.com/jeaye/orchestra) library to instrument
+  `:args`, `:ret`, and `:fn` specs.
+
+  You can use the `:kaocha.plugin/preloads` plugin to ensure namespaces
+  are required (similar to ClojureScript's preloads feature). This is
+  useful to ensure that your specs required before the orchestra plugin
+  instruments your functions.
+
+  Scenario: Enabling Orchestra
+    Given a file named "tests.edn" with:
+    """ clojure
+    #kaocha/v1 {:plugins [:kaocha.plugin/orchestra
+                          :kaocha.plugin/preloads]
+                :kaocha.plugin.preloads/ns-names [thanks.spec]}
+    """
+    And a file named "test/orchestra_test.clj" with:
+    """ clojure
+    (ns orchestra-test
+      (:require [clojure.test :refer :all]
+                ))
+
+    (defn simple-fn []
+      "x")
+
+    (s/fdef simple-fn :ret :simple/int)
+
+    (deftest spec-fail-test
+      (is (= "x" (simple-fn))))
+    """
+    And a file named "src/spec.clj" with:
+    """ clojure
+    (ns spec
+      (:require [clojure.spec.alpha :as s]))
+
+    (s/def :simple/int int?)
+    """
+    When I run `bin/kaocha`
+    And I run `cat /tmp/kaocha.txt`
+    Then the output should contain:
+    ``` nil
+    ⛔️ Failing
+    1 tests, 1 failures.
+    true
+    1
+    critical
+    ```
+
+
+
+


### PR DESCRIPTION
This is a pair of plugins that let you require namespaces (e.g. spec namespaces), and run Orchestra's instrument and instrument at the right points in the test lifecycle.

I've had a go at running the tests but I wasn't able to get them going on macOS.

Feedback welcome!