### PR TITLE
[hooks plugin] Implement before/after hooks on the test suite level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## Added
 
-## Fixed
-
-## Changed
+- The hooks plugin now understands two new hooks at the test suite level,
+  `:kaocha.hooks/before` and `:kaocha.hooks/after`
 
 # 1.0.632 (2020-05-13 / 149d913)
 

--- a/src/kaocha/plugin/hooks.clj
+++ b/src/kaocha/plugin/hooks.clj
@@ -7,20 +7,31 @@
     (update m k f)
     m))
 
+(defn load-hook [h]
+  (cond
+    (qualified-symbol? h)
+    (do
+      (require (symbol (namespace h)))
+      (resolve h))
+
+    (list? h)
+    (eval h)
+
+    :else
+    h))
+
 (defn load-hooks [hs]
-  (mapv (fn [h]
-          (cond
-            (qualified-symbol? h)
-            (do
-              (require (symbol (namespace h)))
-              (resolve h))
+  (if (coll? hs)
+    (mapv load-hook hs)
+    [(load-hook hs)]))
 
-            (list? h)
-            (eval h)
-
-            :else
-            h))
-        hs))
+(defn load-suite-hooks [suites]
+  (map
+   (fn [suite]
+     (-> suite
+         (update? :kaocha.hooks/before load-hooks)
+         (update? :kaocha.hooks/after load-hooks)))
+   suites))
 
 (defplugin kaocha.plugin/hooks
   "Configure hooks directly in `tests.edn`."
@@ -34,7 +45,8 @@
                      (update? :kaocha.hooks/wrap-run load-hooks)
                      (update? :kaocha.hooks/pre-test load-hooks)
                      (update? :kaocha.hooks/post-test load-hooks)
-                     (update? :kaocha.hooks/pre-report load-hooks))]
+                     (update? :kaocha.hooks/pre-report load-hooks)
+                     (update? :kaocha/tests load-suite-hooks))]
       (reduce #(%2 %1) config (:kaocha.hooks/config config))))
 
   (pre-load [config]
@@ -53,10 +65,14 @@
     (reduce #(%2 %1) run (:kaocha.hooks/wrap-run test-plan)))
 
   (pre-test [testable test-plan]
-    (reduce #(%2 %1 test-plan) testable (:kaocha.hooks/pre-test test-plan)))
+    (as-> testable $
+      (reduce #(%2 %1 test-plan) $ (:kaocha.hooks/before testable))
+      (reduce #(%2 %1 test-plan) $ (:kaocha.hooks/pre-test test-plan))))
 
   (post-test [testable test-plan]
-    (reduce #(%2 %1 test-plan) testable (:kaocha.hooks/post-test test-plan)))
+    (as-> testable $
+      (reduce #(%2 %1 test-plan) $ (:kaocha.hooks/post-test test-plan))
+      (reduce #(%2 %1 test-plan) $ (:kaocha.hooks/after testable))))
 
   (pre-report [event]
     (reduce #(%2 %1) event (:kaocha.hooks/pre-report testable/*test-plan*))))

--- a/test/features/plugins/hooks_plugin.feature
+++ b/test/features/plugins/hooks_plugin.feature
@@ -8,6 +8,13 @@ Feature: Plugin: Hooks
   hooks. The supported hooks are: pre-load, post-load, pre-run, post-run,
   pre-test, post-test, pre-report.
 
+  The hooks plugin also provides two extra hooks at the test suite level,
+  `:kaocha.hooks/before` and `:kaocha.hooks/after`, which run respectively
+  before any pre-test, and after any post-test hooks.
+
+  Hooks can be specified as a fully qualified symbol, or a collection thereof.
+  The referenced namespaces will be loaded during the config phase.
+
   Scenario: Implementing a hook
     Given a file named "tests.edn" with:
     """ clojure
@@ -43,4 +50,41 @@ Feature: Plugin: Hooks
     Then the output should contain:
     """
     PENDING sample-test/stdout-fail-test (sample_test.clj:8)
+    """
+
+  Scenario: Implementing a test-suite specific hook
+    Given a file named "tests.edn" with:
+    """ clojure
+#kaocha/v1
+{:plugins [:kaocha.plugin/hooks]
+ :tests [{:id :unit
+          :kaocha.hooks/before [my.kaocha.hooks/sample-before-hook]
+          :kaocha.hooks/after  [my.kaocha.hooks/sample-after-hook]}]}
+    """
+    And a file named "src/my/kaocha/hooks.clj" with:
+    """ clojure
+    (ns my.kaocha.hooks)
+
+    (defn sample-before-hook [suite test-plan]
+      (println "before suite:" (:kaocha.testable/id suite))
+      suite)
+
+    (defn sample-after-hook [suite test-plan]
+      (println "after suite:" (:kaocha.testable/id suite))
+      suite)
+    """
+    And a file named "test/sample_test.clj" with:
+    """ clojure
+    (ns sample-test
+      (:require [clojure.test :refer :all]))
+
+    (deftest stdout-pass-test
+      (println "You peng zi yuan fang lai")
+      (is (= :same :same)))
+    """
+    When I run `bin/kaocha`
+    Then the output should contain:
+    """
+    before suite: :unit
+    [(.)]after suite: :unit
     """


### PR DESCRIPTION
This will be how in kaocha-cljs2 people decide how to compile their ClojureScript and launch their JS runtime.