### PR TITLE
Fall back to config values in test.check plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
             - kaocha/execute:
                 args: "integration --reporter documentation --plugin cloverage --codecov"
                 clojure_version: << parameters.clojure_version >>
+            - kaocha/execute:
+                args: "generative-fdef-checks --reporter documentation"
+                clojure_version: << parameters.clojure_version >>
       - kaocha/upload_codecov:
           flags: integration
           file: target/coverage/integration*/codecov.json

--- a/doc/spec_test_check.md
+++ b/doc/spec_test_check.md
@@ -20,9 +20,9 @@ which may contain the following optional keys:
 `:all-fdefs` (default) or to provide a set of the symbols for the fdefs
 which you want to test. Eventually we will add `:other-fdefs` to select
 all the fdefs that were not specifically mentioned in other checks.
-- `:kaocha.spec.test.check/instrument?` Turn on orchestra instrumentation
+- `:clojure.spec.test.check/instrument?` Turn on orchestra instrumentation
 during fdef checks
-- `:kaocha.spec.test.check/check-asserts?` Run s/check-asserts during fdef
+- `:clojure.spec.test.check/check-asserts?` Run s/check-asserts during fdef
 checks
 - `:clojure.spec.test.check/opts`: A map containing any of:
 - `:num-tests`: Test iterations per fdef
@@ -37,8 +37,8 @@ control.
 - Regardless of whether you add the test suite(s) to `tests.edn` yourself,
 you can also use this plugin to forceably override certain test
 parameters:
-- `--[no-]stc-instrumentation` = `:kaocha.spec.test.check/instrument?`
-- `--[no-]stc-asserts` = `:kaocha.spec.test.check/check-asserts?`
+- `--[no-]stc-instrumentation` = `:clojure.spec.test.check/instrument?`
+- `--[no-]stc-asserts` = `:clojure.spec.test.check/check-asserts?`
 - `--stc-num-tests NUM` = `:num-tests`
 - `--stc-max-size SIZE` = `:max-size`
 - By default, this plugin also adds `:no-gen` to `:kaocha.filter/skip-meta`.

--- a/src/kaocha/plugin/alpha/spec_test_check.clj
+++ b/src/kaocha/plugin/alpha/spec_test_check.clj
@@ -52,12 +52,8 @@
           [nil "--stc-max-size SIZE"        "spec.test.check: Maximum length of generated collections"
            :parse-fn #(Integer/parseInt %)]))
   (config [{:kaocha/keys [tests] :as config}]
-    (let [num-tests       (get-in config
-                                  [:kaocha/cli-options :stc-num-tests]
-                                  (get-in config [::stc/opts :num-tests]))
-          max-size        (get-in config
-                                  [:kaocha/cli-options :stc-max-size]
-                                  (get-in config [::stc/opts :max-size]))
+    (let [num-tests       (get-in config [:kaocha/cli-options :stc-num-tests])
+          max-size        (get-in config [:kaocha/cli-options :stc-max-size])
           instrumentation (get-in config
                                   [:kaocha/cli-options :stc-instrumentation]
                                   (::stc/instrument? config))

--- a/src/kaocha/plugin/alpha/spec_test_check.clj
+++ b/src/kaocha/plugin/alpha/spec_test_check.clj
@@ -1,26 +1,20 @@
 (ns kaocha.plugin.alpha.spec-test-check
-  (:require [clojure.spec.alpha :as s]
+  (:require [clojure.spec.alpha]
             [clojure.spec.test.alpha]
-            [kaocha.hierarchy :as kaocha]
             [kaocha.plugin :refer [defplugin]]
-            [kaocha.specs]
-            [kaocha.testable :as default-test-suite]
-            [kaocha.type :as type]
-            [kaocha.type.spec.test.check :as type.stc]
-            [kaocha.type.spec.test.fdef :as type.fdef]
-            [clojure.string :as str]))
+            [kaocha.specs]))
 
 ;; This namespace does not actually exist, but is created by
 ;; requiring clojure.spec.test.alpha
 (alias 'stc 'clojure.spec.test.check)
 
-(def is-stc? (comp #{:kaocha.type/spec.test.check}
-                   :kaocha.testable/type))
+(def ^:private is-stc? (comp #{:kaocha.type/spec.test.check}
+                             :kaocha.testable/type))
 
-(defn has-stc? [tests]
+(defn ^:private has-stc? [tests]
   (some is-stc? tests))
 
-(defn tests-with-overridden-stc-opts
+(defn ^:private tests-with-overridden-stc-opts
   [{:kaocha/keys [tests] ::stc/keys [opts] :as config}]
   (map (fn [test]
          (if (is-stc? test)
@@ -28,7 +22,7 @@
            test))
        tests))
 
-(defn default-test-suite [{::stc/keys [opts] :as config}]
+(defn ^:private default-test-suite [{::stc/keys [opts] :as config}]
   {:kaocha.testable/type        :kaocha.type/spec.test.check
    :kaocha.testable/id          :generative-fdef-checks
    :kaocha.filter/skip-meta     [:kaocha/skip :no-gen]
@@ -36,10 +30,10 @@
    :kaocha.spec.test.check/syms :all-fdefs
    ::stc/opts                   opts})
 
-(defn override-stc-settings [config]
+(defn ^:private override-stc-settings [config]
   (assoc config :kaocha/tests (tests-with-overridden-stc-opts config)))
 
-(defn add-default-test-suite [config]
+(defn ^:private add-default-test-suite [config]
   (update config :kaocha/tests conj (default-test-suite config)))
 
 (defplugin kaocha.plugin.alpha/spec-test-check

--- a/src/kaocha/result.clj
+++ b/src/kaocha/result.clj
@@ -9,7 +9,7 @@
    ::fail    (apply - (map :fail [after before]))
    ::pending (apply - (map :pending [after before]))})
 
-(defn sum
+(defn ^:no-gen sum
   "Sum up kaocha result maps."
   [& rs]
   {::count   (apply + (map #(::count % 0) rs))
@@ -31,7 +31,7 @@
   [testables]
   (apply sum (map testable-totals testables)))
 
-(defn testable-totals
+(defn ^:no-gen testable-totals
   "Return a map of summed up results for a testable, including descendants."
   [testable]
   (if-let [testables (::tests testable)]

--- a/src/kaocha/testable.clj
+++ b/src/kaocha/testable.clj
@@ -71,7 +71,7 @@
                    :kaocha.error/missing-method `load
                    :kaocha/testable             testable})))
 
-(defn load
+(defn ^:no-gen load
   "Given a testable, load the specified tests, producing a test-plan.
 
   Also performs validation, and lazy loading of the testable type's
@@ -116,7 +116,7 @@
                    :kaocha.error/missing-method `run
                    :kaocha/testable             testable})))
 
-(defn run
+(defn ^:no-gen run
   "Given a test-plan, perform the tests, returning the test results.
 
   Also performs validation, and lazy loading of the testable type's

--- a/test/unit/kaocha/plugin/alpha/spec_test_check_test.clj
+++ b/test/unit/kaocha/plugin/alpha/spec_test_check_test.clj
@@ -1,5 +1,5 @@
 (ns kaocha.plugin.alpha.spec-test-check-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest testing is]]
             [clojure.tools.cli :as cli]
             [kaocha.plugin :as plugin]))
 

--- a/test/unit/kaocha/plugin/alpha/spec_test_check_test.clj
+++ b/test/unit/kaocha/plugin/alpha/spec_test_check_test.clj
@@ -5,7 +5,8 @@
 
 (alias 'stc 'clojure.spec.test.check)
 
-(defn run-plugin-hook [hook init & extra-args]
+(defn run-plugin-hook
+  [hook init & extra-args]
   (let [chain (plugin/load-all [:kaocha.plugin.alpha/spec-test-check])]
     (apply plugin/run-hook* chain hook init extra-args)))
 
@@ -14,91 +15,73 @@
     (testing "--[no-]stc-instrumentation"
       (is (= {:stc-instrumentation true}
              (:options (cli/parse-opts ["--stc-instrumentation"] cli-opts))))
-
       (is (= {:stc-instrumentation false}
              (:options (cli/parse-opts ["--no-stc-instrumentation"] cli-opts)))))
-
     (testing "--[no-]stc-asserts"
       (is (= {:stc-asserts true}
              (:options (cli/parse-opts ["--stc-asserts"] cli-opts))))
-
       (is (= {:stc-asserts false}
              (:options (cli/parse-opts ["--no-stc-asserts"] cli-opts)))))
-
     (testing "--stc-num-tests"
       (is (= {:stc-num-tests 5}
-             (:options (cli/parse-opts ["--stc-num-tests" "5"] cli-opts)))))
-
+             (:options (cli/parse-opts ["--stc-num-tests" "5"]
+                                       cli-opts)))))
     (testing "--stc-max-size"
       (is (= {:stc-max-size 10}
-             (:options (cli/parse-opts ["--stc-max-size" "10"] cli-opts)))))))
+             (:options (cli/parse-opts ["--stc-max-size" "10"]
+                                       cli-opts)))))))
 
 (deftest config-test
   (testing "::stc/instrument?"
     (is (match? {::stc/instrument? nil}
                 (run-plugin-hook :kaocha.hooks/config {})))
-
     (is (match? {::stc/instrument? true}
-                (run-plugin-hook :kaocha.hooks/config
-                                 {::stc/instrument? true})))
-
+                (run-plugin-hook :kaocha.hooks/config {::stc/instrument? true})))
     (is (match? {::stc/instrument? false}
                 (run-plugin-hook :kaocha.hooks/config
                                  {::stc/instrument? false})))
-
     (is (match? {::stc/instrument? nil}
-                (run-plugin-hook :kaocha.hooks/config
-                                 {:kaocha/cli-options {}})))
-
+                (run-plugin-hook :kaocha.hooks/config {:kaocha/cli-options {}})))
     (is (match? {::stc/instrument? true}
                 (run-plugin-hook :kaocha.hooks/config
                                  {:kaocha/cli-options {:stc-instrumentation
                                                        true}})))
-
     (is (match? {::stc/instrument? false}
                 (run-plugin-hook :kaocha.hooks/config
                                  {:kaocha/cli-options {:stc-instrumentation
                                                        false}}))))
-
   (testing "::stc/check-asserts?"
     (is (match? {::stc/check-asserts? nil}
                 (run-plugin-hook :kaocha.hooks/config {})))
-
     (is (match? {::stc/check-asserts? true}
                 (run-plugin-hook :kaocha.hooks/config
                                  {::stc/check-asserts? true})))
-
     (is (match? {::stc/check-asserts? true}
                 (run-plugin-hook :kaocha.hooks/config
                                  {::stc/check-asserts? true
-                                  :kaocha/cli-options {}})))
-
+                                  :kaocha/cli-options  {}})))
     (is (match? {::stc/check-asserts? false}
                 (run-plugin-hook :kaocha.hooks/config
                                  {::stc/check-asserts? true
-                                  :kaocha/cli-options {:stc-asserts false}}))))
-
+                                  :kaocha/cli-options  {:stc-asserts false}}))))
   (testing "::stc/opts"
-    (is (match? {::stc/opts {}}
-                (run-plugin-hook :kaocha.hooks/config {})))
-
-    (is (match? {::stc/opts {:num-tests 5}}
-                (run-plugin-hook :kaocha.hooks/config
-                                 {::stc/opts {:num-tests 5}})))
-
-    (is (match? {::stc/opts {:num-tests 5}}
-                (run-plugin-hook :kaocha.hooks/config
-                                 {:stc/opts {:num-tests 10}
-                                  :kaocha/cli-options {:stc-num-tests 5}})))
-
-    (is (match? {::stc/opts {}}
-                (run-plugin-hook :kaocha.hooks/config {})))
-
-    (is (match? {::stc/opts {:max-size 5}}
-                (run-plugin-hook :kaocha.hooks/config
-                                 {::stc/opts {:max-size 5}})))
-
-    (is (match? {::stc/opts {:max-size 5}}
-                (run-plugin-hook :kaocha.hooks/config
-                                 {:stc/opts {:max-size 10}
-                                  :kaocha/cli-options {:stc-max-size 5}})))))
+    (testing "when there is no existing test suite"
+      (is (match? {::stc/opts {}} (run-plugin-hook :kaocha.hooks/config {})))
+      (is (match? {::stc/opts {:num-tests 5}}
+                  (run-plugin-hook :kaocha.hooks/config
+                                   {:kaocha/cli-options {:stc-num-tests 5}})))
+      (is (match? {::stc/opts {}} (run-plugin-hook :kaocha.hooks/config {})))
+      (is (match? {::stc/opts {:max-size 5}}
+                  (run-plugin-hook :kaocha.hooks/config
+                                   {:kaocha/cli-options {:stc-max-size 5}}))))
+    (testing "when there is no existing test suite"
+      (is (match? {::stc/opts {:num-tests 5}}
+                  (run-plugin-hook
+                   :kaocha.hooks/config
+                   {:kaocha/tests       [{::stc/opts {:num-tests 1000}}]
+                    :kaocha/cli-options {:stc-num-tests 5}})))
+      (is (match? {::stc/opts {:max-size 5}}
+                  (run-plugin-hook
+                   :kaocha.hooks/config
+                   {:kaocha/tests       [{::stc/opts {:max-size 1000}}]
+                    :kaocha/cli-options {:stc-max-size 5}}))))))

--- a/test/unit/kaocha/plugin/alpha/spec_test_check_test.clj
+++ b/test/unit/kaocha/plugin/alpha/spec_test_check_test.clj
@@ -1,0 +1,104 @@
+(ns kaocha.plugin.alpha.spec-test-check-test
+  (:require [clojure.test :refer :all]
+            [clojure.tools.cli :as cli]
+            [kaocha.plugin :as plugin]))
+
+(alias 'stc 'clojure.spec.test.check)
+
+(defn run-plugin-hook [hook init & extra-args]
+  (let [chain (plugin/load-all [:kaocha.plugin.alpha/spec-test-check])]
+    (apply plugin/run-hook* chain hook init extra-args)))
+
+(deftest cli-options-test
+  (let [cli-opts (run-plugin-hook :kaocha.hooks/cli-options [])]
+    (testing "--[no-]stc-instrumentation"
+      (is (= {:stc-instrumentation true}
+             (:options (cli/parse-opts ["--stc-instrumentation"] cli-opts))))
+
+      (is (= {:stc-instrumentation false}
+             (:options (cli/parse-opts ["--no-stc-instrumentation"] cli-opts)))))
+
+    (testing "--[no-]stc-asserts"
+      (is (= {:stc-asserts true}
+             (:options (cli/parse-opts ["--stc-asserts"] cli-opts))))
+
+      (is (= {:stc-asserts false}
+             (:options (cli/parse-opts ["--no-stc-asserts"] cli-opts)))))
+
+    (testing "--stc-num-tests"
+      (is (= {:stc-num-tests 5}
+             (:options (cli/parse-opts ["--stc-num-tests" "5"] cli-opts)))))
+
+    (testing "--stc-max-size"
+      (is (= {:stc-max-size 10}
+             (:options (cli/parse-opts ["--stc-max-size" "10"] cli-opts)))))))
+
+(deftest config-test
+  (testing "::stc/instrument?"
+    (is (match? {::stc/instrument? nil}
+                (run-plugin-hook :kaocha.hooks/config {})))
+
+    (is (match? {::stc/instrument? true}
+                (run-plugin-hook :kaocha.hooks/config
+                                 {::stc/instrument? true})))
+
+    (is (match? {::stc/instrument? false}
+                (run-plugin-hook :kaocha.hooks/config
+                                 {::stc/instrument? false})))
+
+    (is (match? {::stc/instrument? nil}
+                (run-plugin-hook :kaocha.hooks/config
+                                 {:kaocha/cli-options {}})))
+
+    (is (match? {::stc/instrument? true}
+                (run-plugin-hook :kaocha.hooks/config
+                                 {:kaocha/cli-options {:stc-instrumentation
+                                                       true}})))
+
+    (is (match? {::stc/instrument? false}
+                (run-plugin-hook :kaocha.hooks/config
+                                 {:kaocha/cli-options {:stc-instrumentation
+                                                       false}}))))
+
+  (testing "::stc/check-asserts?"
+    (is (match? {::stc/check-asserts? nil}
+                (run-plugin-hook :kaocha.hooks/config {})))
+
+    (is (match? {::stc/check-asserts? true}
+                (run-plugin-hook :kaocha.hooks/config
+                                 {::stc/check-asserts? true})))
+
+    (is (match? {::stc/check-asserts? true}
+                (run-plugin-hook :kaocha.hooks/config
+                                 {::stc/check-asserts? true
+                                  :kaocha/cli-options {}})))
+
+    (is (match? {::stc/check-asserts? false}
+                (run-plugin-hook :kaocha.hooks/config
+                                 {::stc/check-asserts? true
+                                  :kaocha/cli-options {:stc-asserts false}}))))
+
+  (testing "::stc/opts"
+    (is (match? {::stc/opts {}}
+                (run-plugin-hook :kaocha.hooks/config {})))
+
+    (is (match? {::stc/opts {:num-tests 5}}
+                (run-plugin-hook :kaocha.hooks/config
+                                 {::stc/opts {:num-tests 5}})))
+
+    (is (match? {::stc/opts {:num-tests 5}}
+                (run-plugin-hook :kaocha.hooks/config
+                                 {:stc/opts {:num-tests 10}
+                                  :kaocha/cli-options {:stc-num-tests 5}})))
+
+    (is (match? {::stc/opts {}}
+                (run-plugin-hook :kaocha.hooks/config {})))
+
+    (is (match? {::stc/opts {:max-size 5}}
+                (run-plugin-hook :kaocha.hooks/config
+                                 {::stc/opts {:max-size 5}})))
+
+    (is (match? {::stc/opts {:max-size 5}}
+                (run-plugin-hook :kaocha.hooks/config
+                                 {:stc/opts {:max-size 10}
+                                  :kaocha/cli-options {:stc-max-size 5}})))))

--- a/tests.edn
+++ b/tests.edn
@@ -1,5 +1,6 @@
 #kaocha/v1
 {:plugins [:kaocha.plugin.alpha/info
+           :kaocha.plugin.alpha/spec-test-check
            :profiling
            :print-invocations
            :hooks
@@ -14,4 +15,7 @@
                                   "test/features"]
             :cucumber/glue-paths ["test/step_definitions"]}]
 
- :kaocha.hooks/pre-load [kaocha.assertions/load-assertions]}
+ :kaocha.hooks/pre-load [kaocha.assertions/load-assertions]
+
+ :clojure.spec.test.check/instrument? true
+ :clojure.spec.test.check/check-asserts? true}


### PR DESCRIPTION
* Prefer CLI options over config values
* Enable test.check plugin in tests.edn
* Disable some generative fdef checks for functions without adequate generators

Resolves #156.