### PR TITLE
STC plugin and runner improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  kaocha: lambdaisland/kaocha@dev:first
-  clojure: lambdaisland/clojure@dev:first
+  kaocha: lambdaisland/kaocha@0.0.1
+  clojure: lambdaisland/clojure@0.0.1
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@
 
 ## Fixed
 
+- `kaocha.type.spec.test.check` now correctly builds fdef testables with
+  configuration options from their enclosing test suites.
+- `kaocha.plugin.alpha.spec-test-check` now honors command line arguments based
+  upon all of the configured STC suites rather than the static
+  `:generative-fdef-checks` selector.
+
 ## Changed
+
+- `kaocha.plugin.alpha.spec-test-check` now respects a priority of supplied
+  configuration. CLI options always take precedence, followed by options
+  specified in individual test suites, followed by global options.
 
 # 1.0.700 (2020-09-18 / 552b977)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `kaocha.plugin.alpha.spec-test-check` now respects a priority of supplied
   configuration. CLI options always take precedence, followed by options
   specified in individual test suites, followed by global options.
+- Improved spec definitions and generative fdef coverage
 
 # 1.0.700 (2020-09-18 / 552b977)
 

--- a/src/kaocha/plugin/alpha/spec_test_check.clj
+++ b/src/kaocha/plugin/alpha/spec_test_check.clj
@@ -1,13 +1,42 @@
 (ns kaocha.plugin.alpha.spec-test-check
-  (:require [clojure.spec.alpha]
+  (:require [clojure.spec.alpha :as s]
             [clojure.spec.test.alpha]
             [kaocha.plugin :refer [defplugin]]
             [kaocha.specs]
+            [kaocha.type.spec.test.check]
             [meta-merge.core :refer [meta-merge]]))
 
 ;; This namespace does not actually exist, but is created by
 ;; requiring clojure.spec.test.alpha
 (alias 'stc 'clojure.spec.test.check)
+
+(s/def ::config-path
+  (s/coll-of keyword? :min-count 1))
+
+(s/def ::config-mapping
+  (s/map-of ::config-path ::config-path))
+
+(s/def ::stc-config
+  (s/keys :opt [::stc/instrument?
+                ::stc/check-asserts?
+                ::stc/opts]))
+
+(s/def ::cli ::stc-config)
+(s/def ::global ::stc-config)
+
+(s/def ::stc-configs
+  (s/keys :opt [::cli ::global]))
+
+(s/def ::test
+  (s/or :stc-test   :kaocha.type/spec.test.check
+        :other-test :kaocha/testable))
+
+(s/def ::tests
+  (s/coll-of ::test))
+
+(s/fdef is-stc?
+  :args (s/cat :test ::test)
+  :ret  boolean?)
 
 (defn ^:private is-stc?
   [test]
@@ -26,12 +55,20 @@
    [::stc/opts :num-tests]
    [::stc/opts :max-size]])
 
-(def ^:private cli-paths
+(def ^:private cli-config-paths
   (mapv (partial vector :kaocha/cli-options)
         [:stc-instrumentation
          :stc-asserts
          :stc-num-tests
          :stc-max-size]))
+
+(s/fdef make-config-mapping
+  :args (s/cat :instrument?-path    ::config-path
+               :check-asserts?-path ::config-path
+               :opts-num-tests-path ::config-path
+               :opts-max-size-path  ::config-path)
+  :ret  (s/map-of ::config-path ::config-path
+                  :count (count config-paths)))
 
 (defn ^:private make-config-mapping
   [instrument?-path check-asserts?-path opts-num-tests-path opts-max-size-path]
@@ -42,20 +79,26 @@
     (apply hash-map (interleave paths config-paths))))
 
 (def ^:private config-mappings
-  {:cli    (apply make-config-mapping cli-paths)
-   :global (apply make-config-mapping config-paths)})
+  {::cli    (apply make-config-mapping cli-config-paths)
+   ::global (apply make-config-mapping config-paths)})
+
+(s/fdef override-test-stc-config
+  :args (s/cat :tests       (s/nilable ::tests)
+               :stc-configs ::stc-configs)
+  :ret  ::tests)
 
 (defn ^:private override-test-stc-config
   [tests stc-configs]
   (map (fn [test]
          (if (is-stc? test)
-           (meta-merge (:global stc-configs) test (:cli stc-configs))
+           (meta-merge (::global stc-configs) test (::cli stc-configs))
            test))
        tests))
 
-(defn ^:private update-tests
-  [config & args]
-  (apply update config :kaocha/tests args))
+(s/fdef extract-stc-config
+  :args (s/cat :config         :kaocha/config
+               :config-mapping ::config-mapping)
+  :ret  :kaocha/config)
 
 (defn ^:private extract-stc-config
   [config config-mapping]
@@ -66,6 +109,10 @@
              {}
              config-mapping))
 
+(s/fdef extract-stc-configs
+  :args (s/cat :config :kaocha/config)
+  :ret  ::stc-configs)
+
 (defn ^:private extract-stc-configs
   [config]
   (reduce-kv (fn [acc key config-mapping]
@@ -73,12 +120,20 @@
              {}
              config-mappings))
 
+(s/fdef override-stc-config
+  :args (s/cat :config :kaocha/config)
+  :ret  :kaocha/config)
+
 (defn ^:private override-stc-config
   [config]
   (let [stc-configs (extract-stc-configs config)]
     (-> config
-        (meta-merge (:cli stc-configs))
-        (update-tests override-test-stc-config stc-configs))))
+        (meta-merge (::cli stc-configs))
+        (update :kaocha/tests override-test-stc-config stc-configs))))
+
+(s/fdef ensure-stc-suite
+  :args (s/cat :tests (s/nilable ::tests))
+  :ret  ::tests)
 
 (defn ^:private ensure-stc-suite
   [tests]
@@ -86,17 +141,36 @@
     tests
     (conj tests default-stc-suite)))
 
-(def ^:private extract-testable-ids-xform
-  (comp (filter is-stc?) (map :kaocha.testable/id)))
+(def ^:private extract-stc-suite-ids-xform
+  (comp (filter is-stc?)
+        (map :kaocha.testable/id)))
+
+(s/fdef stc-suite-ids
+  :args (s/cat :config :kaocha/config)
+  :ret  (s/coll-of keyword? :kind set?))
 
 (defn ^:private stc-suite-ids
   [config]
-  (into #{} extract-testable-ids-xform (:kaocha/tests config)))
+  (into #{} extract-stc-suite-ids-xform (:kaocha/tests config)))
+
+(s/fdef stc-suites-not-selected?
+  :args (s/cat :config :kaocha/config))
 
 (defn ^:private stc-suites-not-selected?
   [{:kaocha/keys [cli-args] :as config}]
   (and (seq cli-args)
        (not-any? (stc-suite-ids config) cli-args)))
+
+(s/fdef config-hook
+  :args (s/cat :config :kaocha/config)
+  :ret  :kaocha/config)
+
+(defn ^:private config-hook
+  [config]
+  (let [config-with-suite (update config :kaocha/tests ensure-stc-suite)]
+    (if (stc-suites-not-selected? config-with-suite)
+      config
+      (override-stc-config config-with-suite))))
 
 (defplugin kaocha.plugin.alpha/spec-test-check
   (cli-options [opts]
@@ -108,7 +182,4 @@
           [nil "--stc-max-size SIZE"        "spec.test.check: Maximum length of generated collections"
            :parse-fn #(Integer/parseInt %)]))
   (config [config]
-    (let [config-with-suite (update-tests config ensure-stc-suite)]
-      (if (stc-suites-not-selected? config-with-suite)
-        config
-        (override-stc-config config-with-suite)))))
+    (config-hook config)))

--- a/src/kaocha/plugin/alpha/spec_test_check.clj
+++ b/src/kaocha/plugin/alpha/spec_test_check.clj
@@ -2,39 +2,101 @@
   (:require [clojure.spec.alpha]
             [clojure.spec.test.alpha]
             [kaocha.plugin :refer [defplugin]]
-            [kaocha.specs]))
+            [kaocha.specs]
+            [meta-merge.core :refer [meta-merge]]))
 
 ;; This namespace does not actually exist, but is created by
 ;; requiring clojure.spec.test.alpha
 (alias 'stc 'clojure.spec.test.check)
 
-(def ^:private is-stc? (comp #{:kaocha.type/spec.test.check}
-                             :kaocha.testable/type))
+(defn ^:private is-stc?
+  [test]
+  (= (:kaocha.testable/type test) :kaocha.type/spec.test.check))
 
-(defn ^:private has-stc? [tests]
-  (some is-stc? tests))
-
-(defn ^:private tests-with-overridden-stc-opts
-  [{:kaocha/keys [tests] ::stc/keys [opts] :as config}]
-  (map (fn [test]
-         (if (is-stc? test)
-           (update test assoc ::stc/opts opts)
-           test))
-       tests))
-
-(defn ^:private default-test-suite [{::stc/keys [opts] :as config}]
+(def ^:private default-stc-suite
   {:kaocha.testable/type        :kaocha.type/spec.test.check
    :kaocha.testable/id          :generative-fdef-checks
    :kaocha.filter/skip-meta     [:kaocha/skip :no-gen]
-   :kaocha/source-paths         ["src"],
-   :kaocha.spec.test.check/syms :all-fdefs
-   ::stc/opts                   opts})
+   :kaocha/source-paths         ["src"]
+   :kaocha.spec.test.check/syms :all-fdefs})
 
-(defn ^:private override-stc-settings [config]
-  (assoc config :kaocha/tests (tests-with-overridden-stc-opts config)))
+(def ^:private config-paths
+  [[::stc/instrument?]
+   [::stc/check-asserts?]
+   [::stc/opts :num-tests]
+   [::stc/opts :max-size]])
 
-(defn ^:private add-default-test-suite [config]
-  (update config :kaocha/tests conj (default-test-suite config)))
+(def ^:private cli-paths
+  (mapv (partial vector :kaocha/cli-options)
+        [:stc-instrumentation
+         :stc-asserts
+         :stc-num-tests
+         :stc-max-size]))
+
+(defn ^:private make-config-mapping
+  [instrument?-path check-asserts?-path opts-num-tests-path opts-max-size-path]
+  (let [paths [instrument?-path
+               check-asserts?-path
+               opts-num-tests-path
+               opts-max-size-path]]
+    (apply hash-map (interleave paths config-paths))))
+
+(def ^:private config-mappings
+  {:cli    (apply make-config-mapping cli-paths)
+   :global (apply make-config-mapping config-paths)})
+
+(defn ^:private override-test-stc-config
+  [tests stc-configs]
+  (map (fn [test]
+         (if (is-stc? test)
+           (meta-merge (:global stc-configs) test (:cli stc-configs))
+           test))
+       tests))
+
+(defn ^:private update-tests
+  [config & args]
+  (apply update config :kaocha/tests args))
+
+(defn ^:private extract-stc-config
+  [config config-mapping]
+  (reduce-kv (fn [acc source-path dest-path]
+               (if-some [setting (get-in config source-path)]
+                 (assoc-in acc dest-path setting)
+                 acc))
+             {}
+             config-mapping))
+
+(defn ^:private extract-stc-configs
+  [config]
+  (reduce-kv (fn [acc key config-mapping]
+               (assoc acc key (extract-stc-config config config-mapping)))
+             {}
+             config-mappings))
+
+(defn ^:private override-stc-config
+  [config]
+  (let [stc-configs (extract-stc-configs config)]
+    (-> config
+        (meta-merge (:cli stc-configs))
+        (update-tests override-test-stc-config stc-configs))))
+
+(defn ^:private ensure-stc-suite
+  [tests]
+  (if (some is-stc? tests)
+    tests
+    (conj tests default-stc-suite)))
+
+(def ^:private extract-testable-ids-xform
+  (comp (filter is-stc?) (map :kaocha.testable/id)))
+
+(defn ^:private stc-suite-ids
+  [config]
+  (into #{} extract-testable-ids-xform (:kaocha/tests config)))
+
+(defn ^:private stc-suites-not-selected?
+  [{:kaocha/keys [cli-args] :as config}]
+  (and (seq cli-args)
+       (not-any? (stc-suite-ids config) cli-args)))
 
 (defplugin kaocha.plugin.alpha/spec-test-check
   (cli-options [opts]
@@ -45,25 +107,8 @@
            :parse-fn #(Integer/parseInt %)]
           [nil "--stc-max-size SIZE"        "spec.test.check: Maximum length of generated collections"
            :parse-fn #(Integer/parseInt %)]))
-  (config [{:kaocha/keys [tests cli-args] :as config}]
-    (if (and (seq cli-args)
-             (not (some #{:generative-fdef-checks} cli-args)))
-      config
-      (let [num-tests       (get-in config [:kaocha/cli-options :stc-num-tests])
-            max-size        (get-in config [:kaocha/cli-options :stc-max-size])
-            instrumentation (get-in config
-                                    [:kaocha/cli-options :stc-instrumentation]
-                                    (::stc/instrument? config))
-            spec-asserts    (get-in config
-                                    [:kaocha/cli-options :stc-asserts]
-                                    (::stc/check-asserts? config))
-            config          (if (has-stc? tests)
-                              (override-stc-settings config)
-                              (add-default-test-suite config))]
-        (assoc config
-               ::stc/opts (->> {:num-tests num-tests
-                                :max-size  max-size}
-                               (filter second)
-                               (into {}))
-               ::stc/instrument? instrumentation
-               ::stc/check-asserts? spec-asserts)))))
+  (config [config]
+    (let [config-with-suite (update-tests config ensure-stc-suite)]
+      (if (stc-suites-not-selected? config-with-suite)
+        config
+        (override-stc-config config-with-suite)))))

--- a/src/kaocha/type/clojure/test.clj
+++ b/src/kaocha/type/clojure/test.clj
@@ -7,6 +7,7 @@
             [kaocha.classpath :as classpath]
             [kaocha.hierarchy :as hierarchy]
             [kaocha.load :as load]
+            [kaocha.specs]
             [kaocha.test-suite :as test-suite]
             [clojure.java.io :as io]
             [clojure.test :as t]))
@@ -22,10 +23,6 @@
 (s/def :kaocha.type/clojure.test (s/keys :req [:kaocha/source-paths
                                                :kaocha/test-paths
                                                :kaocha/ns-patterns]))
-
-(s/def :kaocha/source-paths (s/coll-of string?))
-(s/def :kaocha/test-paths (s/coll-of string?))
-(s/def :kaocha/ns-patterns (s/coll-of string?))
 
 (hierarchy/derive! :kaocha.type/clojure.test :kaocha.testable.type/suite)
 (hierarchy/derive! :kaocha.type/ns :kaocha.testable.type/group)

--- a/src/kaocha/type/spec/test/check.clj
+++ b/src/kaocha/type/spec/test/check.clj
@@ -31,7 +31,7 @@
     (condp = syms
       :all-fdefs   (all-fdef-tests check)
       :other-fdefs nil ;; TODO: this requires orchestration from the plugin
-      :else        (type.fdef/load-testables syms))))
+      :else        (type.fdef/load-testables check syms))))
 
 (defn checks [{checks :kaocha.spec.test.check/checks :as testable}]
   (let [checks (or checks [{}])]

--- a/src/kaocha/type/spec/test/check.clj
+++ b/src/kaocha/type/spec/test/check.clj
@@ -5,6 +5,7 @@
             [kaocha.core-ext :refer :all]
             [kaocha.hierarchy :as hierarchy]
             [kaocha.load :as load]
+            [kaocha.specs]
             [kaocha.test-suite :as test-suite]
             [kaocha.testable :as testable]
             [kaocha.type :as type]
@@ -50,6 +51,8 @@
 (s/def :kaocha.spec.test.check/syms
   (s/or :given-symbols (s/coll-of symbol?)
         :catch-all #{:all-fdefs :other-fdefs}))
+
+(s/def :kaocha.spec.test.check/ns-patterns :kaocha/ns-patterns)
 
 (s/def :kaocha.spec.test.check/check
   (s/keys :opt [:kaocha.spec.test.check/syms

--- a/src/kaocha/type/spec/test/ns.clj
+++ b/src/kaocha/type/spec/test/ns.clj
@@ -27,14 +27,14 @@
 
 (stest/checkable-syms)
 
-(type.fdef/load-testables '[kaocha.result/sum])
+(type.fdef/load-testables '[kaocha.result/sum] {})
 
 (defmethod testable/-load :kaocha.type/spec.test.ns [testable]
   (let [ns-name (:kaocha.ns/name testable)
         ns-obj  (ns/required-ns ns-name)
         tests   (->> (stest/checkable-syms)
                      (filter (partial starts-with-namespace? ns-name))
-                     (type.fdef/load-testables))]
+                     (type.fdef/load-testables testable))]
     (assoc testable
            :kaocha.testable/meta (meta ns-obj)
            :kaocha.ns/ns ns-obj

--- a/test/unit/kaocha/plugin/alpha/spec_test_check_test.clj
+++ b/test/unit/kaocha/plugin/alpha/spec_test_check_test.clj
@@ -102,7 +102,8 @@
                                    ::stc/check-asserts?  true
                                    ::stc/opts            {:num-tests 5
                                                           :max-size  5}}
-                                  {:kaocha.testable/id :unit}]
+                                  {:kaocha.testable/id   :unit
+                                   :kaocha.testable/type :kaocha.type/clojure.test}]
             ::stc/instrument?    true
             ::stc/check-asserts? true
             ::stc/opts           {:num-tests 5
@@ -118,7 +119,8 @@
                                ::stc/opts            {:num-tests 1000}}
                               {:kaocha.testable/type :kaocha.type/spec.test.check
                                :kaocha.testable/id   :my-ok-fdefs}
-                              {:kaocha.testable/id :unit}]
+                              {:kaocha.testable/id   :unit
+                               :kaocha.testable/type :kaocha.type/clojure.test}]
         ::stc/check-asserts? true
         ::stc/opts           {:num-tests 10
                               :max-size  5}

--- a/tests.edn
+++ b/tests.edn
@@ -1,6 +1,7 @@
 #kaocha/v1
 {:plugins [:kaocha.plugin.alpha/info
            :kaocha.plugin.alpha/spec-test-check
+           :kaocha.plugin/orchestra
            :profiling
            :print-invocations
            :hooks
@@ -21,5 +22,13 @@
 
  :clojure.spec.test.check/instrument? true
  :clojure.spec.test.check/check-asserts? true
+ :clojure.spec.test.check/opts
+ #profile {;; Halving the default opts to prevent CircleCI from killing the test
+           ;; process for lack of output.
+           :ci {:num-tests 500 :max-size 100}
+           ;; Reducing num-tests by two orders of magnitude in local
+           ;; development greatly speeds up iteration time at the expense of
+           ;; possible false negatives.
+           :default {:num-tests 10}}
 
  :reporter kaocha.report/documentation}


### PR DESCRIPTION
- The STC plugin now respects config precedence. CLI options always override test suite and global configuration. Test suite configuration takes precedence over global configuration.
- The STC plugin now reads the suite IDs from config to determine if it needs to skip any config overriding when test selectors are provided, rather than just checking against the static :generative-fdef-checks selector.
- The STC runner now adds test suite configuration to the generated fdef testables. Previously, no options specified within the test suite were respected by the fdef runner.

Resolves #160.