### PR TITLE
Specs for raw configuration values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 node_modules
 package-lock.json
 .store
+test-results

--- a/src/kaocha/api.clj
+++ b/src/kaocha/api.clj
@@ -57,7 +57,9 @@
    (let [fail-fast? (:kaocha/fail-fast? config)
          reporter   (:kaocha/reporter config)
          reporter   (-> reporter
-                        (cond-> (not (vector? reporter)) vector)
+                        (cond->
+                            (not (sequential? reporter)) vector
+                            (seq? reporter) vec)
                         (conj 'kaocha.report/report-counters
                               'kaocha.history/track
                               'kaocha.report/dispatch-extra-keys)

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -4,17 +4,23 @@
             [kaocha.output :as output]
             [kaocha.report :as report]
             [slingshot.slingshot :refer [throw+]]
+            [orchestra.core :refer [defn-spec]]
             [meta-merge.core :refer [meta-merge]]))
 
 (defn default-config []
   (aero/read-config (io/resource "kaocha/default_config.edn")))
 
-(defn- rename-key [m old-key new-key]
+(defn-spec ^:private rename-key map?
+  [m       map?
+   old-key keyword?
+   new-key qualified-keyword?]
   (if (contains? m old-key)
     (assoc (dissoc m old-key) new-key (get m old-key))
     m))
 
-(defn replace-by-default [config k]
+(defn-spec replace-by-default map?
+  [config map?
+   k      keyword?]
   (if-let [v (get config k)]
     (if (#{:prepend :append} (meta v))
       config
@@ -29,7 +35,8 @@
                      (replace-by-default :kaocha/source-paths)
                      (replace-by-default :kaocha/ns-patterns))))
 
-(defn normalize-test-suite [m]
+(defn-spec normalize-test-suite :kaocha/testable
+  [m :kaocha.raw/testable]
   (let [m (-> m
               (rename-key :type :kaocha.testable/type)
               (rename-key :id :kaocha.testable/id)
@@ -55,7 +62,8 @@
             (throw (ex-info "Plugin name must be a keyword" {:plugins plugins}))))
         plugins))
 
-(defn normalize [config]
+(defn-spec normalize :kaocha/config
+  [config :kaocha.raw/config]
   (let [default-config (default-config)
         {:keys [tests
                 plugins

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -51,7 +51,9 @@
       (merge-config (first (:kaocha/tests (default-config))) $)
       (merge {:kaocha.testable/desc (str (name (:kaocha.testable/id $))
                                          " (" (name (:kaocha.testable/type $)) ")")}
-             $))))
+             $)
+      (update $ :kaocha.filter/focus (partial map keyword))
+      (update $ :kaocha.filter/skip (partial map keyword)))))
 
 (defn normalize-plugin-names [plugins]
   (mapv (fn [p]

--- a/src/kaocha/history.clj
+++ b/src/kaocha/history.clj
@@ -6,21 +6,25 @@
 
 (defmulti track :type :hierarchy #'hierarchy/hierarchy)
 
-(defmethod track :default [m] (swap! *history* conj m))
+(defmethod track :default [m]
+  (when *history* (swap! *history* conj m)))
 
 (defmethod track :kaocha/fail-type [m]
-  (swap! *history* conj (assoc m
-                               :testing-contexts t/*testing-contexts*
-                               :testing-vars t/*testing-vars*)) )
+  (when *history*
+    (swap! *history* conj (assoc m
+                                 :testing-contexts t/*testing-contexts*
+                                 :testing-vars t/*testing-vars*))) )
 
 (defmethod track :error [m]
-  (swap! *history* conj (assoc m
-                               :testing-contexts t/*testing-contexts*
-                               :testing-vars t/*testing-vars*)))
+  (when *history*
+    (swap! *history* conj (assoc m
+                                 :testing-contexts t/*testing-contexts*
+                                 :testing-vars t/*testing-vars*))))
 
 (defn clojure-test-summary
   ([]
-   (clojure-test-summary @*history*))
+   (when *history*
+     (clojure-test-summary @*history*)))
   ([history]
    (reduce
     (fn [m {type :type :as event}]

--- a/src/kaocha/result.clj
+++ b/src/kaocha/result.clj
@@ -1,5 +1,6 @@
 (ns kaocha.result
-  (:require [clojure.spec.alpha :as s]))
+  (:require [clojure.spec.alpha :as s]
+            [orchestra.core :refer [defn-spec]]))
 
 (defn diff-test-result
   "Subtract two clojure.test style summary maps."
@@ -9,20 +10,16 @@
    ::fail    (apply - (map :fail [after before]))
    ::pending (apply - (map :pending [after before]))})
 
-(defn sum
+(s/def ::result-map (s/keys :req [::count ::pass ::error ::fail ::pending]))
+
+(defn-spec sum ::result-map
   "Sum up kaocha result maps."
-  [& rs]
+  [& rs (s/cat :args (s/* ::result-map))]
   {::count   (apply + (map #(::count % 0) rs))
    ::pass    (apply + (map #(::pass % 0) rs))
    ::error   (apply + (map #(::error % 0) rs))
    ::fail    (apply + (map #(::fail % 0) rs))
    ::pending (apply + (map #(::pending % 0) rs))})
-
-(s/def ::result-map (s/keys :req [::count ::pass ::error ::fail ::pending]))
-
-(s/fdef sum
-  :args (s/cat :args (s/* ::result-map))
-  :ret ::result-map)
 
 (declare testable-totals)
 

--- a/src/kaocha/specs.clj
+++ b/src/kaocha/specs.clj
@@ -39,7 +39,7 @@
 ;; config
 
 
-(s/def :kaocha/bindings (s/map-of qualified-symbol? (s/coll-of keyword?)))
+(s/def :kaocha/bindings (s/map-of qualified-symbol? any?))
 
 (s/def :kaocha.testable/meta (s/nilable map?))
 

--- a/src/kaocha/specs.clj
+++ b/src/kaocha/specs.clj
@@ -53,9 +53,9 @@
 
 (s/def :kaocha/ns-patterns (s/coll-of string?))
 
-(s/def :kaocha.filter/skip (s/coll-of symbol?))
+(s/def :kaocha.filter/skip (s/coll-of keyword?))
 
-(s/def :kaocha.filter/focus (s/coll-of symbol?))
+(s/def :kaocha.filter/focus (s/coll-of keyword?))
 
 (s/def :kaocha.filter/skip-meta (s/coll-of keyword?))
 

--- a/src/kaocha/type/spec/test/ns.clj
+++ b/src/kaocha/type/spec/test/ns.clj
@@ -23,12 +23,6 @@
 (defn starts-with-namespace? [ns-name sym-or-kw]
   (-> sym-or-kw namespace (= (str ns-name))))
 
-(ns/required-ns 'kaocha.result)
-
-(stest/checkable-syms)
-
-(type.fdef/load-testables '[kaocha.result/sum] {})
-
 (defmethod testable/-load :kaocha.type/spec.test.ns [testable]
   (let [ns-name (:kaocha.ns/name testable)
         ns-obj  (ns/required-ns ns-name)

--- a/tests.edn
+++ b/tests.edn
@@ -23,9 +23,9 @@
  :clojure.spec.test.check/instrument? true
  :clojure.spec.test.check/check-asserts? true
  :clojure.spec.test.check/opts
- #profile {;; Halving the default opts to prevent CircleCI from killing the test
+ #profile {;; Quartering the default opts to prevent CircleCI from killing the test
            ;; process for lack of output.
-           :ci {:num-tests 500 :max-size 100}
+           :ci {:num-tests 250 :max-size 50}
            ;; Reducing num-tests by two orders of magnitude in local
            ;; development greatly speeds up iteration time at the expense of
            ;; possible false negatives.


### PR DESCRIPTION
This is a continuation of #163. This add more spec definitions, specifically around raw, unprocessed configuration, where much of the data can be optionally specified and specified without qualification. With this, a few more functions can have fdefs written for them, and it makes a clearer delineation between input configuration and internal configuration.