### PR TITLE
Add spec validation for the list of plugins.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  kaocha: lambdaisland/kaocha@dev:first
-  clojure: lambdaisland/clojure@dev:first
+  kaocha: lambdaisland/kaocha@0.0.1
+  clojure: lambdaisland/clojure@0.0.1
 
 jobs:
   test:

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -154,7 +154,11 @@
                                                               (config/load-config (if profile
                                                                                     {:profile profile}
                                                                                     {})))
-          _check (specs/assert-spec :kaocha/config config)
+          _check                                          (try 
+                                                            (specs/assert-spec :kaocha/config config)
+                                                            (catch AssertionError e 
+                                                              (println (.toString e))
+                                                              (throw+ {:kaocha/early-exit 0})))
           plugin-chain                                    (plugin/load-all (concat (:kaocha/plugins config) plugin))
           cli-options                                     (plugin/run-hook* plugin-chain :kaocha.hooks/cli-options cli-options)
 

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -154,6 +154,7 @@
                                                               (config/load-config (if profile
                                                                                     {:profile profile}
                                                                                     {})))
+          _check (specs/assert-spec :kaocha/config config)
           plugin-chain                                    (plugin/load-all (concat (:kaocha/plugins config) plugin))
           cli-options                                     (plugin/run-hook* plugin-chain :kaocha.hooks/cli-options cli-options)
 

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -157,8 +157,9 @@
           _check                                          (try 
                                                             (specs/assert-spec :kaocha/config config)
                                                             (catch AssertionError e 
-                                                              (println (.toString e))
-                                                              (throw+ {:kaocha/early-exit 0})))
+                                                              (output/error "Invalid configuration file:\n" 
+                                                                            (.getMessage e))
+                                                              (throw+ {:kaocha/early-exit 252})))
           plugin-chain                                    (plugin/load-all (concat (:kaocha/plugins config) plugin))
           cli-options                                     (plugin/run-hook* plugin-chain :kaocha.hooks/cli-options cli-options)
 


### PR DESCRIPTION
Addresses #36 using @plexus's suggested solution of adding a spec validation check early on.

I added a simple exception handler to just print the exception name and spec failed message, so it looks like the following:

```
java.lang.AssertionError: -- Spec failed --------------------

  {:kaocha/bindings ...,
   :kaocha/tests ...,
   :kaocha/fail-fast? ...,
   :kaocha/color? ...,
   :clojure.spec.test.check/instrument? ...,
   :kaocha/plugins
   [... ... ... kaocha.plugin.alpha/info ... ... ... ... ...],
                ^^^^^^^^^^^^^^^^^^^^^^^^
   :kaocha/reporter ...,
   :clojure.spec.test.check/check-asserts? ...,
   :kaocha.hooks/pre-load ...}

should satisfy

  keyword?

-- Relevant specs -------

:kaocha/plugins:
  (clojure.spec.alpha/coll-of clojure.core/keyword?)
:kaocha/config:
  (clojure.spec.alpha/keys :req ~(conj global-opts :kaocha/tests))

-------------------------
Detected 1 error
```

It looks like Kaocha code base uses `(throw+ {:kaocha/early-exit 0})` in this circumstance, although I'm not sure if the error code is the one we want.