### PR TITLE
Update docs to suggest using :dev profile for Leiningen

### DIFF
--- a/doc/02_installing.md
+++ b/doc/02_installing.md
@@ -98,11 +98,12 @@ projects. The rest of the documentation assumes you can invoke Kaocha with
 lein kaocha "$@"
 ```
 
+For more information on `:dev`, see the [Leiningen docs](https://cljdoc.org/d/leiningen/leiningen/2.9.3/doc/profiles#default-profiles).
 
 #### Alternative method: separate `:kaocha` profile
 
 If you want to use Kaocha only in certain circumstances, say when
-[profiling tests](08_plugins.md#profiling), you may not want to add it to your :dev profile.
+[profiling tests](08_plugins.md#profiling), you may not want to add it to your `:dev` profile.
 
 Instead, add a `:kaocha` profile with the Kaocha dependency, then add an
 alias that activates the profile and invokes `lein run -m kaocha.runner`:

--- a/doc/02_installing.md
+++ b/doc/02_installing.md
@@ -73,14 +73,13 @@ bin/kaocha --version
 
 ### Leiningen
 
-Add a `:kaocha` profile, where the Kaocha dependency is included, then add an
-alias that activates the profile, and invokes `lein run -m kaocha.runner`.
+Add Kaocha to your `:dev` profile, then add an alias that invokes `lein run -m kaocha.runner`:
 
 ``` clojure
 (defproject my-proj "0.1.0"
   :dependencies [,,,]
-  :profiles {:kaocha {:dependencies [[lambdaisland/kaocha "1.0.700"]]}}
-  :aliases {"kaocha" ["with-profile" "+kaocha" "run" "-m" "kaocha.runner"]})
+  :profiles {:dev {:dependencies [,,, [lambdaisland/kaocha "1.0.700"]]}}
+  :aliases {"kaocha" ["run" "-m" "kaocha.runner"]})
 ```
 
 Now you can invoke Kaocha as such:
@@ -98,6 +97,25 @@ projects. The rest of the documentation assumes you can invoke Kaocha with
 
 lein kaocha "$@"
 ```
+
+
+#### Alternative method: separate `:kaocha` profile
+
+If you want to use Kaocha only in certain circumstances, say when
+[profiling tests](08_plugins.md#profiling), you may not want to add it to your :dev profile.
+
+Instead, add a `:kaocha` profile with the Kaocha dependency, then add an
+alias that activates the profile and invokes `lein run -m kaocha.runner`:
+
+``` clojure
+(defproject my-proj "0.1.0"
+  :dependencies [,,,]
+  :profiles {:kaocha {:dependencies [[lambdaisland/kaocha "1.0.700"]]}}
+  :aliases {"kaocha" ["with-profile" "+kaocha" "run" "-m" "kaocha.runner"]})
+```
+
+Invoking Kaocha and creating `bin/kaocha` will work the same way. However,
+Kaocha will not be available in your REPL by default.
 
 ### Boot
 


### PR DESCRIPTION
Since a test runner is a core part of the dev workflow, it makes more sense to add Kaocha as a dependency to `:dev` than as as separate profile. 

It does sometimes make sense to use a separate profile, so I'm keeping that information but putting it in a separate section that clarifies the tradeoffs.

Addresses #118 and #166.