### PR TITLE
Make sure we can still run Kaocha when test.check is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - `kaocha.plugin.alpha.spec-test-check` now honors command line arguments based
   upon all of the configured STC suites rather than the static
   `:generative-fdef-checks` selector.
+- Fix an issue where clojure.test.check would be required for Kaocha to work,
+  rather than being an optional dependency
 
 ## Changed
 


### PR DESCRIPTION
Use wrappers for `s/gen` and `s/with-gen`, when we are unable to load
test.check.generators we use simple stubs.

Fixes #159 