### PR TITLE
Ensure runner works without test.check.

### DIFF
--- a/src/kaocha/specs.clj
+++ b/src/kaocha/specs.clj
@@ -12,7 +12,7 @@
   (require 'clojure.test.check.generators)
   (def s-gen @(resolve 'clojure.spec.alpha/gen))
   (def s-with-gen @(resolve 'clojure.spec.alpha/with-gen))
-  (def s-fspec @(resolve 'clojure.spec.alpha/fspec))
+  (defmacro s-fspec [& args] `(s/fspec ~@args))
   (catch FileNotFoundException _))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/kaocha/specs.clj
+++ b/src/kaocha/specs.clj
@@ -6,11 +6,13 @@
 
 (defn s-gen [_])
 (defn s-with-gen [spec _] spec)
+(defn s-fspec [_ __] any?)
 
 (try
   (require 'clojure.test.check.generators)
   (def s-gen @(resolve 'clojure.spec.alpha/gen))
   (def s-with-gen @(resolve 'clojure.spec.alpha/with-gen))
+  (def s-fspec @(resolve 'clojure.spec.alpha/fspec))
   (catch FileNotFoundException _))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -24,7 +26,7 @@
 
 (s/def :kaocha/plugins (s/coll-of keyword?))
 
-(s/def :kaocha/reporter (s/or :fn      (s/fspec :args (s/cat :m map?))
+(s/def :kaocha/reporter (s/or :fn      (s-fspec :args (s/cat :m map?))
                               :symbol  symbol?
                               :symbols (s/coll-of symbol? :kind vector?)))
 


### PR DESCRIPTION
Users are still running into issue #159. It happens soon after starting `bin/kaocha` because the problematic spec is used to check the config.

I narrowed it down, and the problem is in the`kaocha/report` spec. `clojure.spec.alpha.fspec` actually requires test.check, which is [a known limitation](https://clojure.atlassian.net/browse/CLJ-1936#icft=CLJ-1936). ~~To fix this, I used the same technique as in #171 .~~ (see comment below)