### PR TITLE
Retry tests

### DIFF
--- a/src/kaocha/plugin/retry.clj
+++ b/src/kaocha/plugin/retry.clj
@@ -1,0 +1,25 @@
+(ns kaocha.plugin.retry
+  "Instrument/unstrument namespaces with Orchestra, to get validation of function
+  arguments and return values based on clojure.spec.alpha."
+  (:require [kaocha.plugin :refer [defplugin]]
+            [orchestra.spec.test :as orchestra]
+            [clojure.spec.alpha :as spec]))
+
+(defplugin kaocha.plugin/retry
+  (post-run [result]
+    (println "test was run with result" (keys result))
+    (println "error = "
+             (-> result
+                 ;; :kaocha.result
+                 :kaocha.result/tests
+                 first
+                 :kaocha.result/tests
+                 ;; keys
+                 ;; first
+                 #_:kaocha.result/error)
+             "fail ="
+             #_(-> result
+                 :kaocha.result/tests
+                 ;; first
+                 #_:kaocha.result/fail))
+    result))

--- a/src/kaocha/plugin/retry.clj
+++ b/src/kaocha/plugin/retry.clj
@@ -2,24 +2,41 @@
   "Instrument/unstrument namespaces with Orchestra, to get validation of function
   arguments and return values based on clojure.spec.alpha."
   (:require [kaocha.plugin :refer [defplugin]]
-            [orchestra.spec.test :as orchestra]
-            [clojure.spec.alpha :as spec]))
+            [kaocha.hierarchy :as h]
+            [kaocha.testable :as t]
+            [kaocha.result :as r]))
+
+(def max-retries 3)
+(def wait-time 100)
+;; this needs to be reset in a fixture before every test
+(def current-retries (atom {}))
+
+(defn any-failed? []
+  (let [v (vals @current-retries)]
+    (and (seq v)
+         (= 3 (apply max v)))))
 
 (defplugin kaocha.plugin/retry
-  (post-run [result]
-    (println "test was run with result" (keys result))
-    (println "error = "
-             (-> result
-                 ;; :kaocha.result
-                 :kaocha.result/tests
-                 first
-                 :kaocha.result/tests
-                 ;; keys
-                 ;; first
-                 #_:kaocha.result/error)
-             "fail ="
-             #_(-> result
-                 :kaocha.result/tests
-                 ;; first
-                 #_:kaocha.result/fail))
-    result))
+  (pre-report [event]
+    (if (any-failed?)
+      event
+      (assoc event :type :pass)))
+
+  (pre-run [test-plan]
+    (reset! current-retries {})
+    test-plan)
+
+  (post-test [test test-plan]
+    (let [t-id (:kaocha.testable/id test)
+          curr (get @current-retries t-id 0)]
+      (when (and
+             (h/leaf? test)
+             (r/failed-one? test)
+             (< curr max-retries))
+
+        (println "Retrying time " @current-retries)
+        (swap! current-retries assoc t-id (inc curr))
+        (Thread/sleep wait-time)
+        (t/run-testable test test-plan))
+
+      test)))

--- a/tests.edn
+++ b/tests.edn
@@ -2,6 +2,7 @@
 {:plugins [:kaocha.plugin.alpha/info
            :kaocha.plugin.alpha/spec-test-check
            :kaocha.plugin/orchestra
+           :kaocha.plugin/retry
            :profiling
            :print-invocations
            :hooks


### PR DESCRIPTION
Attempt to retry failed tests automatically.
This plugin should:
- find out all the tests that failed
- re-run them a max number of times (with some delay between retries)
- log the re-runs but report the tests like the intermediate failures weren't there