### PR TITLE
Throw error when on a version of Clojure prior to 1.9.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Fixed
 
+- Clearly alert the user that Cloure 1.9 isn't supported, rather than
+    failing on whatever 1.9 functionality happens to be invoked first.
+
 ## Changed
 
 # 1.0.732 (2020-11-26 / b418350)

--- a/src/kaocha/api.clj
+++ b/src/kaocha/api.clj
@@ -1,4 +1,4 @@
-(require 'kaocha.version_check)
+(require 'kaocha.version-check)
 (ns kaocha.api
   "Programmable test runner interface."
   (:require [clojure.test :as t]

--- a/src/kaocha/api.clj
+++ b/src/kaocha/api.clj
@@ -1,3 +1,4 @@
+(require 'kaocha.version_check)
 (ns kaocha.api
   "Programmable test runner interface."
   (:require [clojure.test :as t]

--- a/src/kaocha/core_ext.clj
+++ b/src/kaocha/core_ext.clj
@@ -5,6 +5,7 @@
   (:require  [kaocha.output :as output]
             [slingshot.slingshot :refer [try+ throw+]]))
 
+;This ends up being the best place to put the version check to avoid duplication.
 (when-not (and (>= (:major *clojure-version*) 1) (>= (:minor *clojure-version*) 9))
                        (output/error "Kaocha requires Clojure 1.9 or later.")
                        (throw+ {:kaocha/early-exit 251}))

--- a/src/kaocha/core_ext.clj
+++ b/src/kaocha/core_ext.clj
@@ -6,7 +6,8 @@
             [slingshot.slingshot :refer [try+ throw+]]))
 
 ;This ends up being the best place to put the version check to avoid duplication.
-(when-not (and (>= (:major *clojure-version*) 1) (>= (:minor *clojure-version*) 9))
+(when-not (or (and (= (:major *clojure-version*) 1) (>= (:minor *clojure-version*) 9))
+              (>= (:major *clojure-version*) 2))
                        (output/error "Kaocha requires Clojure 1.9 or later.")
                        (throw+ {:kaocha/early-exit 251}))
 

--- a/src/kaocha/core_ext.clj
+++ b/src/kaocha/core_ext.clj
@@ -3,7 +3,6 @@
   (:refer-clojure :exclude [symbol])
   (:import [java.util.regex Pattern]))
 
-
 (defn regex? [x]
   (instance? Pattern x))
 

--- a/src/kaocha/core_ext.clj
+++ b/src/kaocha/core_ext.clj
@@ -1,15 +1,8 @@
 (ns kaocha.core-ext
   "Core language extensions"
   (:refer-clojure :exclude [symbol])
-  (:import [java.util.regex Pattern])
-  (:require  [kaocha.output :as output]
-            [slingshot.slingshot :refer [try+ throw+]]))
+  (:import [java.util.regex Pattern]))
 
-;This ends up being the best place to put the version check to avoid duplication.
-(when-not (or (and (= (:major *clojure-version*) 1) (>= (:minor *clojure-version*) 9))
-              (>= (:major *clojure-version*) 2))
-                       (output/error "Kaocha requires Clojure 1.9 or later.")
-                       (throw+ {:kaocha/early-exit 251}))
 
 (defn regex? [x]
   (instance? Pattern x))

--- a/src/kaocha/core_ext.clj
+++ b/src/kaocha/core_ext.clj
@@ -1,7 +1,13 @@
 (ns kaocha.core-ext
   "Core language extensions"
   (:refer-clojure :exclude [symbol])
-  (:import [java.util.regex Pattern]))
+  (:import [java.util.regex Pattern])
+  (:require  [kaocha.output :as output]
+            [slingshot.slingshot :refer [try+ throw+]]))
+
+(when-not (and (>= (:major *clojure-version*) 1) (>= (:minor *clojure-version*) 9))
+                       (output/error "Kaocha requires Clojure 1.9 or later.")
+                       (throw+ {:kaocha/early-exit 251}))
 
 (defn regex? [x]
   (instance? Pattern x))

--- a/src/kaocha/plugin.clj
+++ b/src/kaocha/plugin.clj
@@ -1,4 +1,3 @@
-
 (require 'kaocha.version-check)
 (ns kaocha.plugin
   (:require [kaocha.output :as output]

--- a/src/kaocha/plugin.clj
+++ b/src/kaocha/plugin.clj
@@ -1,3 +1,5 @@
+
+(require 'kaocha.version-check)
 (ns kaocha.plugin
   (:require [kaocha.output :as output]
             [clojure.string :as str]

--- a/src/kaocha/repl.clj
+++ b/src/kaocha/repl.clj
@@ -1,4 +1,4 @@
-(require 'kaocha.version_check)
+(require 'kaocha.version-check)
 (ns ^{:author "Arne Brasseur"
       :doc "REPL interface to Kaocha
 

--- a/src/kaocha/repl.clj
+++ b/src/kaocha/repl.clj
@@ -1,3 +1,4 @@
+(require 'kaocha.version_check)
 (ns ^{:author "Arne Brasseur"
       :doc "REPL interface to Kaocha
 

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -1,7 +1,8 @@
+(require 'kaocha.version_check)
 (ns kaocha.runner
   "Main entry point for command line use."
   (:gen-class)
-  (:require [kaocha.api :as api]; DO NOT MOVE. This needs to be first for the sake of the version check.
+  (:require [kaocha.api :as api]
             [clojure.java.io :as io]
             [clojure.pprint :as pprint]
             [clojure.set :as set]

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -1,14 +1,14 @@
 (ns kaocha.runner
   "Main entry point for command line use."
   (:gen-class)
-  (:require [clojure.java.io :as io]
+  (:require [kaocha.api :as api]
+            [clojure.java.io :as io]
             [clojure.pprint :as pprint]
             [clojure.set :as set]
             [clojure.spec.alpha :as spec]
             [clojure.string :as str]
             [clojure.tools.cli :as cli]
             [expound.alpha :as expound]
-            [kaocha.api :as api]
             [kaocha.config :as config]
             [kaocha.jit :refer [jit]]
             [kaocha.output :as output]

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -1,7 +1,7 @@
 (ns kaocha.runner
   "Main entry point for command line use."
   (:gen-class)
-  (:require [kaocha.api :as api]
+  (:require [kaocha.api :as api]; DO NOT MOVE. This needs to be first for the sake of the version check.
             [clojure.java.io :as io]
             [clojure.pprint :as pprint]
             [clojure.set :as set]

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -1,4 +1,4 @@
-(require 'kaocha.version_check)
+(require 'kaocha.version-check)
 (ns kaocha.runner
   "Main entry point for command line use."
   (:gen-class)

--- a/src/kaocha/version_check.clj
+++ b/src/kaocha/version_check.clj
@@ -1,8 +1,8 @@
 (ns kaocha.version-check
-  (:require  [kaocha.output :as output]
+  (:require [kaocha.output :as output]
             [slingshot.slingshot :refer [throw+]]))
 
-(defn check-version-minimum 
+(defn check-version-minimum
   "Checks that Clojure has at least a minimum version"
   [major minor]
   (when-not (or (and (= (:major *clojure-version*) major) (>= (:minor *clojure-version*) minor))

--- a/src/kaocha/version_check.clj
+++ b/src/kaocha/version_check.clj
@@ -1,0 +1,14 @@
+(ns kaocha.version-check
+  (:require  [kaocha.output :as output]
+            [slingshot.slingshot :refer [throw+]]))
+
+(defn check-version-minimum 
+  "Checks that Clojure has at least a minimum version"
+  [major minor]
+  (when-not (or (and (= (:major *clojure-version*) major) (>= (:minor *clojure-version*) minor))
+                (>= (:major *clojure-version*) (inc major) ))
+    (let [msg (format "Kaocha requires Clojure %d.%d or later." major minor)]
+      (output/error msg)
+      (throw+ {:kaocha/early-exit 251} msg))))
+
+(check-version-minimum 1 9)

--- a/test/unit/kaocha/version_check_test.clj
+++ b/test/unit/kaocha/version_check_test.clj
@@ -4,7 +4,6 @@
             [kaocha.test-helper]
             [kaocha.version-check :as v]))
 
-
 (deftest earlier-version-throws
   (is (thrown-ex-data? "Kaocha requires Clojure 1.9 or later." 
                        {:kaocha/early-exit 251} (binding [*clojure-version* {:major 1 :minor 8}]

--- a/test/unit/kaocha/version_check_test.clj
+++ b/test/unit/kaocha/version_check_test.clj
@@ -1,0 +1,22 @@
+
+(ns kaocha.version-check-test
+  (:require [clojure.test :refer :all]
+            [kaocha.test-helper]
+            [kaocha.version-check :as v]))
+
+
+(deftest earlier-version-throws
+  (is (thrown-ex-data? "Kaocha requires Clojure 1.9 or later." 
+                       {:kaocha/early-exit 251} (binding [*clojure-version* {:major 1 :minor 8}]
+                 (v/check-version-minimum 1 9)))))
+
+
+(deftest current-version-does-not-throw
+  (is (nil? (binding [*clojure-version* {:major 1 :minor 9}]
+        (v/check-version-minimum 1 9)))))
+
+
+(deftest version-2-does-not-throw
+  (is (nil? (binding [*clojure-version* {:major 2 :minor 0}]
+        (v/check-version-minimum 1 9)))))
+

--- a/test/unit/kaocha/version_check_test.clj
+++ b/test/unit/kaocha/version_check_test.clj
@@ -1,21 +1,19 @@
-
 (ns kaocha.version-check-test
   (:require [clojure.test :refer :all]
             [kaocha.test-helper]
             [kaocha.version-check :as v]))
 
 (deftest earlier-version-throws
-  (is (thrown-ex-data? "Kaocha requires Clojure 1.9 or later." 
-                       {:kaocha/early-exit 251} (binding [*clojure-version* {:major 1 :minor 8}]
-                 (v/check-version-minimum 1 9)))))
-
+  (is (thrown-ex-data?
+       "Kaocha requires Clojure 1.9 or later."
+       {:kaocha/early-exit 251}
+       (binding [*clojure-version* {:major 1 :minor 8}]
+         (v/check-version-minimum 1 9)))))
 
 (deftest current-version-does-not-throw
   (is (nil? (binding [*clojure-version* {:major 1 :minor 9}]
-        (v/check-version-minimum 1 9)))))
-
+              (v/check-version-minimum 1 9)))))
 
 (deftest version-2-does-not-throw
   (is (nil? (binding [*clojure-version* {:major 2 :minor 0}]
-        (v/check-version-minimum 1 9)))))
-
+              (v/check-version-minimum 1 9)))))


### PR DESCRIPTION
Addresses #37. Checking for the Clojure version is a bit tricky because the initial errors come during the import process, so they can't be handled during the normal program flow. 

The only alternative I came up with would be to enclose problematic imports in `try`s. Since we don't support earlier versions, littering the codebase with checks for it seems like a bad tradeoff.