### PR TITLE
Fix arg order in load-error generator

### DIFF
--- a/src/kaocha/specs.clj
+++ b/src/kaocha/specs.clj
@@ -89,7 +89,7 @@
 
 (s/def :kaocha.test-plan/load-error (s-with-gen
                                      #(instance? Throwable %)
-                                     #(s-gen #{(ex-info {:oops "not good"} "load error")})))
+                                     #(s-gen #{(ex-info "load error" {:oops "not good"})})))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; result


### PR DESCRIPTION
The arguments to ex-info in this generator were transposed. Previously, any time spec tried to generate a `:kaocha.test-plan/load-error`, it threw a ClassCastException.