### PR TITLE
Warn when the user has no config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Fixed
 
-- Clearly alert the user that Cloure 1.9 isn't supported, rather than
+- Clearly alert the user that Clojure versions before 1.9 aren't supported, rather than
     failing on whatever 1.9 functionality happens to be invoked first.
 - Fixed an issue with the definition of spec `:kaocha.test-plan/load-error` that
     caused a ClassCastException whenever a generator was created for it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
     failing on whatever 1.9 functionality happens to be invoked first.
 - Fixed an issue with the definition of spec `:kaocha.test-plan/load-error` that
     caused a ClassCastException whenever a generator was created for it.
+- Warn when running Kaocha without a configuration file. This is fine for
+    experimenting, but for long-term use, we recommend creating a configuration
+    file to avoid changes in behavior between releases.
 
 ## Changed
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ bin/kaocha --test-help
 
 ## Requirements
 
-Kaocha requirements Clojure 1.9 or later.
+Kaocha requires Clojure 1.9 or later.
 
 <!-- contributing -->
 ## Contributing

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -6,6 +6,9 @@
             [slingshot.slingshot :refer [throw+]]
             [meta-merge.core :refer [meta-merge]]))
 
+;the reader literal for the current default:
+(def current-reader 'kaocha/v1)
+
 (defn default-config []
   (aero/read-config (io/resource "kaocha/default_config.edn")))
 
@@ -80,7 +83,7 @@
       :->                     (merge (dissoc config :tests :plugins :reporter :color? :fail-fast? :watch? :randomize?)))))
 
 (defmethod aero/reader 'kaocha [_opts _tag value]
-  (output/warn "The #kaocha reader literal is deprecated, please change it to #kaocha/v1.")
+  (output/warn (format "The #kaocha reader literal is deprecated, please change it to %s." current-reader))
   (-> (default-config)
       (merge-config (normalize value))))
 


### PR DESCRIPTION
If we change the defaults and create a new reader literal for them, `#kaocha/v2`, people with a tests.edn will be fine—they're either using a completely custom config or they're loading a set of defaults they're happy with using `#kaocha/v1`. However, people not using a configuration file at all might see changes in behavior.

To help avoid this, we should warn users when they don't have a configuration file.


```
WARNING: Did not load a configuration file and using the defaults.
This is fine for experimenting, but for long-term use, we recommend creating a configuration file to avoid changes in behavior between releases.
To create a configuration file using the current defaults, create a file named tests.edn that contains 'kaocha/v1 {}'.
```