### PR TITLE
Add Java 15 to our test matrix.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,5 +39,5 @@ workflows:
       - test:
           matrix:
             parameters:
-              os: [clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
+              os: [clojure/openjdk15-buster, clojure/openjdk11, clojure/openjdk8]
               clojure_version: ["1.9.0", "1.10.1"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,5 +39,5 @@ workflows:
       - test:
           matrix:
             parameters:
-              os: [clojure/openjdk15-buster, clojure/openjdk11, clojure/openjdk8]
+              os: [clojure/openjdk-15-buster, clojure/openjdk11, clojure/openjdk8]
               clojure_version: ["1.9.0", "1.10.1"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   kaocha: lambdaisland/kaocha@0.0.1
-  clojure: lambdaisland/clojure@0.0.1
+  clojure: lambdaisland/clojure@0.0.2
 
 jobs:
   test:
@@ -39,5 +39,5 @@ workflows:
       - test:
           matrix:
             parameters:
-              os: [clojure/openjdk-15-buster, clojure/openjdk11, clojure/openjdk8]
+              os: [clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
               clojure_version: ["1.9.0", "1.10.1"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,5 +39,5 @@ workflows:
       - test:
           matrix:
             parameters:
-              os: [clojure/openjdk11, clojure/openjdk8]
+              os: [clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
               clojure_version: ["1.9.0", "1.10.1"]


### PR DESCRIPTION
While the Clojure team generally recommends LTS releases, between 10 and 30 percent of Clojure users target more recent versions. Plus, if there's an incompatibility introduced after Java 11, it would be good to know now, rather than when we add the next Java LTS. 