### PR TITLE
Balance braces in example tests.edn in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ tests found in `src/` and `/test`, in any namespace).
 #kaocha/v1
 {:tests [{:id          :unit
           :test-paths  ["test" "src"]
-          :ns-patterns [".*"]}]}
+          :ns-patterns [".*"]}]
           ;; :reporter kaocha.report.progress/report
           ;; :plugins [:kaocha.plugin/profiling :kaocha.plugin/notifier]
  }


### PR DESCRIPTION
Fix the tests.edn in the README. Small change, but lets someone copy and paste it directly if they want.