### PR TITLE
Initial draft of material about meta-merge.

### DIFF
--- a/doc/03_configuration.md
+++ b/doc/03_configuration.md
@@ -94,9 +94,10 @@ The primary advantage to using the `#meta-merge` tag over aero's
 `#merge` is that meta-merge will do a deep merge of the tree; meaning
 developers can more easily inherit changes to the base configuration.
 
-Meta-merge is also applied by default for ???. You can use `^:prepend`, :`^append`, and` ^:replace` to
-control the merging.  For example, if you wanted to overide the list of default
-plugins rather than add on to it, write:
+Meta-merge is also applied by default for most keys, with some exceptions listed
+below. You can use `^:prepend`, :`^append`, and` ^:replace` to control the
+merging.  For example, if you wanted to overide the list of default plugins
+rather than add on to it, write:
 
 
 ```

--- a/doc/03_configuration.md
+++ b/doc/03_configuration.md
@@ -95,8 +95,8 @@ The primary advantage to using the `#meta-merge` tag over aero's
 developers can more easily inherit changes to the base configuration.
 
 Meta-merge is also applied by default for ???. You can use `^:prepend`, :`^append`, and` ^:replace` to
-control the merging.  For example, if you wanted to overide the list o fefault
-plugins rather than add on to it, you could write:
+control the merging.  For example, if you wanted to overide the list of default
+plugins rather than add on to it, write:
 
 
 ```
@@ -106,7 +106,7 @@ plugins rather than add on to it, you could write:
 The keys `:kaocha/reporter`,
 `:kaocha/tests`, `:kaocha/test-paths`, `:kaocha/source-paths`,
 `:kaocha/ns-patterns` are replaced by default. If you prefer to add on to the
-default namespace paths:
+default namespace paths, write:
 
 ```
 #kaocha/v1 {:ns-patterns ^:append ["^test-"]}

--- a/doc/03_configuration.md
+++ b/doc/03_configuration.md
@@ -94,6 +94,24 @@ The primary advantage to using the `#meta-merge` tag over aero's
 `#merge` is that meta-merge will do a deep merge of the tree; meaning
 developers can more easily inherit changes to the base configuration.
 
+Meta-merge is also applied by default for ???. You can use `^:prepend`, :`^append`, and` ^:replace` to
+control the merging.  For example, if you wanted to overide the list o fefault
+plugins rather than add on to it, you could write:
+
+
+```
+#kaocha/v1 {:plugins ^:replace [:kaocha.plugin/capture-output :kaocha.plugin/orchestra]}
+```
+
+The keys `:kaocha/reporter`,
+`:kaocha/tests`, `:kaocha/test-paths`, `:kaocha/source-paths`,
+`:kaocha/ns-patterns` are replaced by default. If you prefer to add on to the
+default namespace paths:
+
+```
+#kaocha/v1 {:ns-patterns ^:append ["^test-"]}
+```
+
 
 ## Test suites
 

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -32,7 +32,10 @@
           (throw+ {:kaocha/early-exit 250}))))
     config))
 
-(defn merge-config [c1 c2]
+(defn merge-config
+  "Applies meta-merge to c1 and c2, using ^:replace for certain keys if no
+  metadata is specified."
+  [c1 c2]
   (meta-merge c1 (-> c2
                      (replace-by-default :kaocha/reporter)
                      (replace-by-default :kaocha/tests)

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -21,7 +21,7 @@
 
 (defn replace-by-default [config k]
   (if-let [v (get config k)]
-    (if (#{:prepend :append} (meta v))
+    (if (some #{:prepend :append} (keys (meta v)))
       config
       (if (or (coll? v)
               (symbol? v)

--- a/test/unit/kaocha/config_test.clj
+++ b/test/unit/kaocha/config_test.clj
@@ -53,7 +53,16 @@
   (testing "defaults to replacing for certain keys"
     (is (= {:kaocha/reporter ['yyy]}
            (c/merge-config {:kaocha/reporter '[xxx]}
-                           {:kaocha/reporter '[yyy]})))))
+                           {:kaocha/reporter '[yyy]}))))
+  (testing "does not override metadata for replace-by-default key tests"
+    (is (= {:kaocha/tests [{:id :integration} {:id :unit}]}
+          (c/merge-config {:kaocha/tests [{:id :unit}]}
+                          {:kaocha/tests ^:prepend [{:id :integration}]}))))
+  (testing "does not override metadata for replace-by-default key test-paths"
+    (print (meta (:kaocha/test-paths {:kaocha/test-paths ^:append ["integration-tests"]})))
+    (is (= {:kaocha/test-paths ["unit-tests" "integration-tests" ]}
+          (c/merge-config {:kaocha/test-paths ["unit-tests"]}
+                          {:kaocha/test-paths ^:append ["integration-tests"]})))))
 
 (deftest merge-ns-patterns-issue-124-test
   (testing "https://github.com/lambdaisland/kaocha/issues/124"


### PR DESCRIPTION
Adds some documentation about meta-merge, including some examples. I'm not 100 percent sure about what is automatically meta-merged, hence the draft.

Addresses  #184.

Questions:
- [x] ~~What parts of the configuration already have `meta-merge` applied? I think it's "everything except for select forms"~~ Kind of? We apply `meta-merge` to everything, and use `^:replace` for certain things.
- [x] ~~Can `^:prepend`, :`^append`, and` ^:replace` be used with `:kaocha/tests`? I can't get it to work.~~ They were supposed to, but there was a bug.