### PR TITLE
Extend exists? to not cause an issue on Windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Warn when running Kaocha without a configuration file. This is fine for
     experimenting, but for long-term use, we recommend creating a configuration
     file to avoid changes in behavior between releases.
+- Fix exception when running Kaocha on Windows with the built-in notification
+    plugin enabled.
 
 ## Changed
 

--- a/src/kaocha/plugin/notifier.clj
+++ b/src/kaocha/plugin/notifier.clj
@@ -6,8 +6,10 @@
             [kaocha.result :as result]
             [kaocha.shellwords :refer [shellwords]]
             [clojure.string :as str]
-            [clojure.java.io :as io])
-  (:import [java.nio.file Files]))
+            [clojure.java.io :as io]
+            [slingshot.slingshot :refer [throw+]])
+  (:import [java.nio.file Files]
+           [java.io IOException] ))
 
 ;; special thanks for terminal-notify stuff to
 ;; https://github.com/glittershark/midje-notifier/blob/master/src/midje/notifier.clj
@@ -16,7 +18,10 @@
   (let [cmd (if 
               (re-find #"Windows" (System/getProperty "os.name"))
               "where.exe" "which" )]
-    (= 0 (:exit (sh cmd program)))))
+    (try 
+      (= 0 (:exit (sh cmd program)))
+      (catch IOException e  ;in the unlikely event where.exe or which isn't available
+        (throw+ {:kaocha/early-exit 0} e)))))
 
 (defn detect-command []
   (cond

--- a/src/kaocha/plugin/notifier.clj
+++ b/src/kaocha/plugin/notifier.clj
@@ -2,6 +2,7 @@
   {:authors ["Ryan McCuaig (@rgm)"
              "Arne Brasseur (@plexus)"]}
   (:require [clojure.java.shell :refer [sh]]
+            [kaocha.output :as output]
             [kaocha.plugin :refer [defplugin]]
             [kaocha.result :as result]
             [kaocha.shellwords :refer [shellwords]]
@@ -21,7 +22,7 @@
     (try 
       (= 0 (:exit (sh cmd program)))
       (catch IOException e  ;in the unlikely event where.exe or which isn't available
-        (throw+ {:kaocha/early-exit 0} e)))))
+        (output/warn (format "Unable to determine whether '%s' exists." program)) ))))
 
 (defn detect-command []
   (cond

--- a/src/kaocha/plugin/notifier.clj
+++ b/src/kaocha/plugin/notifier.clj
@@ -16,7 +16,7 @@
   (let [cmd (if 
               (re-find #"Windows" (System/getProperty "os.name"))
               "where.exe" "which" )]
-    (= 0 (:exit (sh "which" program)))))
+    (= 0 (:exit (sh cmd program)))))
 
 (defn detect-command []
   (cond

--- a/src/kaocha/plugin/notifier.clj
+++ b/src/kaocha/plugin/notifier.clj
@@ -13,7 +13,10 @@
 ;; https://github.com/glittershark/midje-notifier/blob/master/src/midje/notifier.clj
 
 (defn exists? [program]
-  (= 0 (:exit (sh "which" program))))
+  (let [cmd (if 
+              (re-find #"Windows" (System/getProperty "os.name"))
+              "where.exe" "which" )]
+    (= 0 (:exit (sh "which" program)))))
 
 (defn detect-command []
   (cond


### PR DESCRIPTION
On Windows, there's no `which` command, so our attempt to determine if commands exist fails with an unhelpful error. Addresses #198.
