### PR TITLE
Lower num-tests and see if that helps.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
                 args: "integration --reporter documentation --plugin cloverage --codecov"
                 clojure_version: << parameters.clojure_version >>
             - kaocha/execute:
-                args: "generative-fdef-checks --reporter documentation"
+                args: "generative-fdef-checks --reporter documentation --stc-num-tests 10"
                 clojure_version: << parameters.clojure_version >>
       - kaocha/upload_codecov:
           flags: integration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
                 args: "integration --reporter documentation --plugin cloverage --codecov"
                 clojure_version: << parameters.clojure_version >>
             - kaocha/execute:
-                args: "generative-fdef-checks --reporter documentation --stc-num-tests 10"
+                args: "generative-fdef-checks --reporter documentation --stc-num-tests << parameters.num_tests >>"
                 clojure_version: << parameters.clojure_version >>
       - kaocha/upload_codecov:
           flags: integration
@@ -39,5 +39,6 @@ workflows:
       - test:
           matrix:
             parameters:
-              os: [clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
+              os: [clojure/openjdk8]
               clojure_version: ["1.9.0", "1.10.1"]
+              num_tests: [25, 50]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ jobs:
         type: executor
       clojure_version:
         type: string
+      num_tests:
+        type: integer
     executor: << parameters.os >>
     steps:
       - checkout


### PR DESCRIPTION
`kaocha.plugin.alpha.spec-test-check` consistently fails with what we think is an out-of-memory error. It might be that the generative tests are creating too much garbage, so doing fewer might help.
