### PR TITLE
Add support for Java's notification messages.

### DIFF
--- a/src/kaocha/plugin/notifier.clj
+++ b/src/kaocha/plugin/notifier.clj
@@ -82,9 +82,15 @@
   Not preferred over shelling out because the built-in notification sometimes
   looks out of place, and isn't consistently available on Linux."
   [result]
-  (let [icon (tray-icon "kaocha/clojure_logo.png")
+  (try 
+    (let [icon (tray-icon "kaocha/clojure_logo.png")
         urgency (if (result/failed? result) TrayIcon$MessageType/ERROR TrayIcon$MessageType/INFO) ]
-  (.displayMessage icon (title result) (message result) urgency)))
+  (.displayMessage icon (title result) (message result) urgency))
+    (catch java.awt.HeadlessException e
+      (output/info (str "Notification not shown because system is headless. AWT error: " e))
+            
+            )
+    ))
 
 
 (defn expand-command

--- a/src/kaocha/plugin/notifier.clj
+++ b/src/kaocha/plugin/notifier.clj
@@ -17,8 +17,7 @@
 ;; https://github.com/glittershark/midje-notifier/blob/master/src/midje/notifier.clj
 
 (defn exists? [program]
-  (let [cmd (if 
-              (re-find #"Windows" (System/getProperty "os.name"))
+  (let [cmd (if (re-find #"Windows" (System/getProperty "os.name"))
               "where.exe" "which" )]
     (try 
       (= 0 (:exit (sh cmd program)))
@@ -78,19 +77,16 @@
 
 (defn send-tray-notification 
   "Use Java's built-in functionality to display a notification.
-  
+
   Not preferred over shelling out because the built-in notification sometimes
   looks out of place, and isn't consistently available on Linux."
   [result]
   (try 
     (let [icon (tray-icon "kaocha/clojure_logo.png")
-        urgency (if (result/failed? result) TrayIcon$MessageType/ERROR TrayIcon$MessageType/INFO) ]
-  (.displayMessage icon (title result) (message result) urgency))
+          urgency (if (result/failed? result) TrayIcon$MessageType/ERROR TrayIcon$MessageType/INFO) ]
+      (.displayMessage icon (title result) (message result) urgency))
     (catch java.awt.HeadlessException e
-      (output/info (str "Notification not shown because system is headless. AWT error: " e))
-            
-            )
-    ))
+      (output/warn (str "Notification not shown because system is headless. AWT error: " e)) )))
 
 
 (defn expand-command
@@ -120,6 +116,7 @@
     (apply sh (expand-command command {:message message
                                        :title title
                                        :icon icon
+
                                        :urgency urgency
                                        :count count
                                        :pass pass


### PR DESCRIPTION
The JVM has built-in functionality for notification messages. We don't want to replace the existing use of `notify-send` and `terminal-notifier` because the JVM notifications don't look great on every platform, but it works as a fallback.

![108773981-b9b74400-7524-11eb-8eab-bf677c990f61](https://user-images.githubusercontent.com/1570381/110032212-7e273180-7cfd-11eb-913d-2fce5abc3b41.png)
![108773922-a5734700-7524-11eb-8e63-66a89fa9e891](https://user-images.githubusercontent.com/1570381/110032221-81222200-7cfd-11eb-859b-968217279de8.png)
