### PR TITLE
Set the line endings in the JVM to be consistent across platforms.

### DIFF
--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-clojure -A:dev:test -m kaocha.runner "$@"
+clojure -J-Dline.separator=$'\n' -A:dev:test -m kaocha.runner "$@"


### PR DESCRIPTION
Arne suggested this, and it's much easier than rewriting the tests to not use `\n`. Addresses #206.

Tests
- [x] Test on Windows
- [ ] Test on macOS
- [x] Test on Linux
- [x] Test on CI
