### PR TITLE
Initial fix to syntax errors being overshadowed.

### DIFF
--- a/src/kaocha/api.clj
+++ b/src/kaocha/api.clj
@@ -98,10 +98,11 @@
           (with-bindings (config/binding-map config)
             (let [config (resolve-reporter config)]
               (let [test-plan (test-plan config)]
-                (when-not (some hierarchy/leaf? (testable/test-seq test-plan))
+                (when (and (not (some hierarchy/leaf? (testable/test-seq test-plan)))
+                           (empty? (filter #(contains? % :kaocha.testable/load-error) (get test-plan :kaocha.test-plan/tests) ))) 
                   (output/warn (str "No tests were found, make sure :test-paths and "
                                     ":ns-patterns are configured correctly in tests.edn."))
-                  (throw+ {:kaocha/early-exit 0}))
+                  (throw+ {:kaocha/early-exit 0 }))
                 (when (find-ns 'matcher-combinators.core)
                   (require 'kaocha.matcher-combinators))
 

--- a/test/features/syntax_error.feature
+++ b/test/features/syntax_error.feature
@@ -1,0 +1,19 @@
+
+Feature: Syntax errors are preserved
+  Syntax errors should be passed along.
+  Scenario: Show output of failing test
+    Given a file named "test/sample_test.clj" with:
+      """ clojure
+      (ns sample-test
+        (:require [clojure.test :refer :all]))
+
+      stray-symbol
+
+      (deftest stdout-pass-test
+        (is (= :same :same)))
+      """
+    When I run `bin/kaocha`
+    Then the output should contain:
+    """
+    Exception: clojure.lang.Compiler$CompilerException: Syntax error compiling at (sample_test.clj:0:0).
+    """


### PR DESCRIPTION
Fixes #208.

I can't help but think there's a neater way to fix this, like there's a predicate somewhere I could be using to test if any of the tests have errors.