### PR TITLE
Don't let the "no tests found" message shadow the load error

### DIFF
--- a/bb_deps.edn
+++ b/bb_deps.edn
@@ -1,4 +1,4 @@
 {:deps
  {lambdaisland/open-source {:git/url "https://github.com/lambdaisland/open-source"
-                            :sha "55f81454a62b0688a0702735257cc5473f2f0c60"
+                            :sha "43ea822056ce84017639841ac082b9007a32d0f4"
                             #_#_:local/root "../open-source"}}}

--- a/src/kaocha/api.clj
+++ b/src/kaocha/api.clj
@@ -98,7 +98,9 @@
           (with-bindings (config/binding-map config)
             (let [config (resolve-reporter config)]
               (let [test-plan (test-plan config)]
-                (when-not (some hierarchy/leaf? (testable/test-seq test-plan))
+                (when-not (some #(or (hierarchy/leaf? %)
+                                     (::testable/load-error %))
+                                (testable/test-seq test-plan))
                   (output/warn (str "No tests were found, make sure :test-paths and "
                                     ":ns-patterns are configured correctly in tests.edn."))
                   (throw+ {:kaocha/early-exit 0}))

--- a/test/unit/kaocha/version_check_test.clj
+++ b/test/unit/kaocha/version_check_test.clj
@@ -12,10 +12,8 @@
 
 (deftest current-version-does-not-throw
   (is (nil? (binding [*clojure-version* {:major 1 :minor 9}]
-        (v/check-version-minimum 1 9)))))
-
+              (v/check-version-minimum 1 9)))))
 
 (deftest version-2-does-not-throw
   (is (nil? (binding [*clojure-version* {:major 2 :minor 0}]
-        (v/check-version-minimum 1 9)))))
-
+              (v/check-version-minimum 1 9)))))


### PR DESCRIPTION
When files fail to parse then it's likely no tests can be loaded, in that case
we need to show the error, not the generic "check your config" message.

This should go a long way towards addressing #208, although there still may be other cases where the load error doesn't properly come through.