### PR TITLE
Add Windows CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           command: clojure -h
           shell: powershell.exe
       - run:
-          command: clojure -J-Dline.separator=$'\n' -A:dev:test -m kaocha.runner
+          command: clojure "-J-Dline.separator=`n" -A:dev:test -m kaocha.runner
           shell: powershell.exe
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   kaocha: lambdaisland/kaocha@0.0.1
   clojure: lambdaisland/clojure@0.0.4
+  win: circleci/windows@2.2.0
 
 jobs:
   test:
@@ -29,6 +30,16 @@ jobs:
       - kaocha/upload_codecov:
           flags: integration
           file: target/coverage/integration*/codecov.json
+  windows-test:
+    executor:
+      name: win/default
+    steps:
+      - run:
+          command: $(echo hello | Out-Host; $?) -and $(echo world | Out-Host; $?)
+          shell: powershell.exe
+      - run:
+          command: Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://download.clojure.org/install/win-install-1.10.3.839.ps1')
+          shell: powershell.exe
 
 workflows:
   kaocha_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,6 @@ workflows:
               os: [clojure/openjdk16, clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
               clojure_version: ["1.9.0", "1.10.1"]
 
-      - windows-test
+      # - windows-test
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,9 @@ jobs:
       - run:
           command: clojure -h
           shell: powershell.exe
+      - run:
+          command: clojure -J-Dline.separator=$'\n' -A:dev:test -m kaocha.runner
+          shell: powershell.exe
 
 workflows:
   kaocha_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,12 @@ jobs:
           command: Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://download.clojure.org/install/win-install-1.10.3.839.ps1')
           shell: powershell.exe
       - run:
-          command: clojure -e "(println (System/getProperty `"java.runtime.name`") (System/getProperty `"java.runtime.version`") `"\nClojure`" (clojure-version))"
+          command: clojure -e "(println (System/getProperty \`"java.runtime.name\`") (System/getProperty \`"java.runtime.version\`") \`"`nClojure\`" (clojure-version))"
           shell: powershell.exe
       - run:
-          command: Set-Variable -Name "ErrorActionPreference" -Value "Stop"; clojure "-J-Dline.separator=`n" -A:dev:test -m kaocha.runner  2>&1
+          command: |
+            $erroractionpreference = "Stop"
+            clojure "-J-Dline.separator=`n" -A:dev:test -m kaocha.runner  2>&1
           shell: powershell.exe
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,10 @@ jobs:
           command: Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://download.clojure.org/install/win-install-1.10.3.839.ps1')
           shell: powershell.exe
       - run:
-          command: clojure -h
+          command: clojure -e "(println (System/getProperty `"java.runtime.name`") (System/getProperty `"java.runtime.version`") "\nClojure`" (clojure-version))"
           shell: powershell.exe
       - run:
-          command: clojure "-J-Dline.separator=`n" -A:dev:test -m kaocha.runner
+          command: Set-Variable -Name "ErrorActionPreference" -Value "Stop"; clojure "-J-Dline.separator=`n" -A:dev:test -m kaocha.runner  2>&1
           shell: powershell.exe
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,9 @@ jobs:
       - run:
           command: Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://download.clojure.org/install/win-install-1.10.3.839.ps1')
           shell: powershell.exe
+      - run:
+          command: clojure -h
+          shell: powershell.exe
 
 workflows:
   kaocha_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
     executor:
       name: win/default
     steps:
+      - checkout
       - run:
           command: $(echo hello | Out-Host; $?) -and $(echo world | Out-Host; $?)
           shell: powershell.exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - run:
           command: |
             $ErrorActionPreference = "Stop"
-            clojure "-J-Dline.separator=`n" -A:dev:test -m kaocha.runner  2>&1
+            clojure "-J-Dline.separator=`n" -A:dev:test -m kaocha.runner unit  2>&1
             exit $lastexitcode
           shell: powershell.exe
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,3 +49,7 @@ workflows:
             parameters:
               os: [clojure/openjdk16, clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
               clojure_version: ["1.9.0", "1.10.1"]
+
+      - windows-test
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,9 @@ jobs:
           shell: powershell.exe
       - run:
           command: |
-            $erroractionpreference = "Stop"
+            $ErrorActionPreference = "Stop"
             clojure "-J-Dline.separator=`n" -A:dev:test -m kaocha.runner  2>&1
+            exit $lastexitcode
           shell: powershell.exe
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           command: Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://download.clojure.org/install/win-install-1.10.3.839.ps1')
           shell: powershell.exe
       - run:
-          command: clojure -e "(println (System/getProperty `"java.runtime.name`") (System/getProperty `"java.runtime.version`") "\nClojure`" (clojure-version))"
+          command: clojure -e "(println (System/getProperty `"java.runtime.name`") (System/getProperty `"java.runtime.version`") `"\nClojure`" (clojure-version))"
           shell: powershell.exe
       - run:
           command: Set-Variable -Name "ErrorActionPreference" -Value "Stop"; clojure "-J-Dline.separator=`n" -A:dev:test -m kaocha.runner  2>&1

--- a/test/unit/kaocha/plugin/notifier_test.clj
+++ b/test/unit/kaocha/plugin/notifier_test.clj
@@ -102,7 +102,7 @@
                             (gensym (str (namespace `_) "-" (rand-int 10000))))
         f1 (gen-file-name)
         f2 (gen-file-name)
-        cmd (if (platform/on-windows?) "cmd.exe echo $null >> " "touch ")]
+        cmd (if (platform/on-windows?) "echo.exe $null >> " "touch ")]
 
     (n/notifier-post-run-hook {::n/notifications? true
                                ::n/command (str cmd f1)})

--- a/test/unit/kaocha/plugin/notifier_test.clj
+++ b/test/unit/kaocha/plugin/notifier_test.clj
@@ -102,12 +102,12 @@
                             (gensym (str (namespace `_) "-" (rand-int 10000))))
         f1 (gen-file-name)
         f2 (gen-file-name)
-        cmd (if (platform/on-windows?) "echo.exe $null >> " "touch ")]
+        cmd (if (platform/on-windows?) "powershell 'echo.exe $null >> %s'" "touch %s")]
 
     (n/notifier-post-run-hook {::n/notifications? true
-                               ::n/command (str cmd f1)})
+                               ::n/command (format cmd f1)})
     (is (.isFile (io/file f1)))
 
     (n/notifier-post-run-hook {::n/notifications? false
-                               ::n/command (str cmd f2)})
+                               ::n/command (format cmd f2)})
     (is (not (.isFile (io/file f2))))))

--- a/test/unit/kaocha/watch_test.clj
+++ b/test/unit/kaocha/watch_test.clj
@@ -1,6 +1,7 @@
 (ns kaocha.watch-test
   (:require [clojure.test :refer :all]
             [kaocha.watch :as w]
+            [kaocha.platform :as platform]
             [kaocha.test-util :as util]
             [lambdaisland.tools.namespace.dir :as ctn-dir]
             [clojure.java.shell :as shell]
@@ -77,9 +78,12 @@
   ; Validate that incompatible patterns are converted and match after conversion. 
   (is (w/glob? (.toPath (io/file "xxxx.clj")) [(w/convert "xxx* ")])) 
   (is (w/glob? (.toPath (io/file "xxxx.clj")) [(w/convert "xxx*  ")]))
-  (is (w/glob? (.toPath (io/file "xxxx.clj ")) [(w/convert "xxx*\\ ")]))
-  (is (w/glob? (.toPath (io/file "xxxx.clj ")) [(w/convert "xxx*\\  ")]))
-  (is (w/glob? (.toPath (io/file "xxxx.clj  ")) [(w/convert "xxx*\\ \\ ")]))
+  (when-not (platform/on-windows?) 
+    (is (w/glob? (.toPath (io/file "xxxx.clj ")) [(w/convert "xxx*\\ ")])))
+  (when-not (platform/on-windows?) 
+   (is (w/glob? (.toPath (io/file "xxxx.clj ")) [(w/convert "xxx*\\  ")])))
+  (when-not (platform/on-windows?) 
+   (is (w/glob? (.toPath (io/file "xxxx.clj  ")) [(w/convert "xxx*\\ \\ ")])))
   (is (w/glob? (.toPath (io/file "src/xxx.class")) [(w/convert "src/")]))
   (is (w/glob? (.toPath (io/file "src/xxx.class")) [(w/convert "*.class")]))
   (is (w/glob? (.toPath (io/file "src/clj/test.tmp")) [(w/convert "src/**/test.tmp")]))


### PR DESCRIPTION
This adds Windows to our CI configuration. Once this is figured out, it can serve as a template for other projects. We still have some outstanding issues with these tests, so I'll either wait to merge this or skip the problematic tests on just our Windows build.

- [x] Confirm tests actually run.
- [x] Figure out why errors from `clojure` aren't being treated as failures.
- [ ] Decide whether to skip problematic tests, and if so, add metadata for tests that don't work on Windows.