### PR TITLE
Fix print-invocations for boolean flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 
 ## Fixed
+- Fix printing of boolean options in the print-invocations plugin
 
 ## Changed
 

--- a/src/kaocha/plugin/print_invocations.clj
+++ b/src/kaocha/plugin/print_invocations.clj
@@ -20,8 +20,17 @@
                      (str/join
                       " "
                       (mapcat (fn [[k v]]
-                                (if (vector? v)
+                                (cond
+                                  (vector? v)
                                   (mapcat (fn [v] [(str "--" (name k)) v]) v)
+                                  
+                                  (true? v)
+                                  [(str "--" (name k))]
+                                  
+                                  (false? v)
+                                  [(str "--no-" (name k))]
+                                  
+                                  :else
                                   [(str "--" (name k))  v]))
                               (cond-> (dissoc (:kaocha/cli-options results) :focus)
                                 (= "tests.edn" (:config-file (:kaocha/cli-options results)))


### PR DESCRIPTION
If you run `./bin/kaocha --no-capture-output` and a test fails, it suggests using `bin/kaocha --capture-output false --focus '...'`, which if you try to run it fails with `No such suite: :false, valid options: :unit.` since the `--capture-output` option does not expect any parameters.
To fix this, I added handling for boolean options so that they should get printed correctly.

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
