### PR TITLE
Fix and clean up load-error handling, remove Orchestra

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,6 @@ jobs:
             - kaocha/execute:
                 args: "integration --reporter documentation --plugin cloverage --codecov"
                 clojure_version: << parameters.clojure_version >>
-            - kaocha/execute:
-                args: "generative-fdef-checks --reporter documentation"
-                clojure_version: << parameters.clojure_version >>
       - kaocha/upload_codecov:
           flags: integration
           file: target/coverage/integration*/codecov.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,26 @@
 ## Added
 
 ## Fixed
+
+- Fix load-error handling in `kaocha.watch`
 - Fix printing of boolean options in the print-invocations plugin
+- Fix Java reflection warning in the Notifier plugin
 
 ## Changed
+
+- [BREAKING] Remove the Orchestra dependency, and no longer auto-instrument.
+  You'll have to list Orchestra in your own `deps.edn`/`project.clj` if you want
+  to use the Orchestra plugin.
+- Version bumps of Clojure, tools.cli, spec.alpha, expound
 
 # 1.0.861 (2021-05-21 / dbfd6e8)
 
 ## Added
+
 - Formatting of failed test results using deep-diff can be disabled with `--diff-style :none` on the command line or `:diff-style :none` in `tests.edn`.
 
 ## Fixed
+
 - Fix at least some cases of syntax errors being suppressed by the "no tests found" message.
 
 ## Changed

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-clojure -J-Dline.separator=$'\n' -A:dev:test -m kaocha.runner "$@"
+clojure -J-Dline.separator=$'\n' -A:dev:test -M -m kaocha.runner "$@"

--- a/deps.edn
+++ b/deps.edn
@@ -1,27 +1,29 @@
 {:paths ["src" "resources"]
 
  :deps
- {org.clojure/clojure          {:mvn/version "1.10.1"}
-  org.clojure/spec.alpha       {:mvn/version "0.2.187"}
-  org.clojure/tools.cli        {:mvn/version "1.0.194"}
+ {org.clojure/clojure          {:mvn/version "1.10.3"}
+  org.clojure/spec.alpha       {:mvn/version "0.2.194"}
+  org.clojure/tools.cli        {:mvn/version "1.0.206"}
   lambdaisland/tools.namespace {:mvn/version "0.0-237"}
   lambdaisland/deep-diff       {:mvn/version "0.0-47"}
   org.tcrawley/dynapath        {:mvn/version "1.1.0"}
   slingshot/slingshot          {:mvn/version "0.12.2"}
   hawk/hawk                    {:mvn/version "0.2.11"}
-  expound/expound              {:mvn/version "0.8.5"}
-  orchestra/orchestra          {:mvn/version "2020.07.12-1"}
+  expound/expound              {:mvn/version "0.8.9"}
   aero/aero                    {:mvn/version "1.1.6"}
   progrock/progrock            {:mvn/version "0.1.2"}
   meta-merge/meta-merge        {:mvn/version "1.0.0"}}
 
  :aliases
  {:test
-  {:extra-deps {org.clojure/test.check        {:mvn/version "1.1.0"}
-                lambdaisland/kaocha-cucumber  {:mvn/version "0.0-53" :exclusions [lambdaisland/kaocha]}
-                lambdaisland/kaocha-cloverage {:mvn/version "1.0.75" :exclusions [lambdaisland/kaocha]}
-                nubank/matcher-combinators    {:mvn/version "1.5.2"}
-                akvo/fs                       {:mvn/version "20180904-152732.6dad3934"}}}
+  {:extra-paths ["test/shared" "test/unit"]
+   :extra-deps  {org.clojure/test.check        {:mvn/version "1.1.0"}
+                 lambdaisland/kaocha-cucumber  {:mvn/version "0.0-53" :exclusions [lambdaisland/kaocha]}
+                 lambdaisland/kaocha-cloverage {:mvn/version "1.0.75" :exclusions [lambdaisland/kaocha]}
+                 nubank/matcher-combinators    {:mvn/version "1.5.2"}
+                 akvo/fs                       {:mvn/version "20180904-152732.6dad3934"}
+                 orchestra/orchestra           {:mvn/version "2020.07.12-1"}}}
 
   :dev
-  {}}}
+  {:extra-paths ["dev"]
+   :extra-deps  {djblue/portal {:mvn/version "RELEASE"}}}}}

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,0 +1,17 @@
+(ns user)
+
+(defmacro jit [sym]
+  `(requiring-resolve '~sym))
+
+(def portal-instance (atom nil))
+
+(defn portal
+  "Open a Portal window and register a tap handler for it. The result can be
+  treated like an atom."
+  []
+  ;; Portal is both an IPersistentMap and an IDeref, which confuses pprint.
+  (prefer-method @(jit clojure.pprint/simple-dispatch) clojure.lang.IPersistentMap clojure.lang.IDeref)
+  (let [p ((jit portal.api/open) @portal-instance)]
+    (reset! portal-instance p)
+    (add-tap (jit portal.api/submit))
+    p))

--- a/src/kaocha/api.clj
+++ b/src/kaocha/api.clj
@@ -9,6 +9,7 @@
             [kaocha.plugin :as plugin]
             [kaocha.report :as report]
             [kaocha.result :as result]
+            [kaocha.util :as util]
             [kaocha.stacktrace :as stacktrace]
             [kaocha.testable :as testable]
             [slingshot.slingshot :refer [try+ throw+]]))
@@ -72,10 +73,10 @@
                                           (if (:kaocha/fail-fast (ex-data e))
                                             (throw e)
                                             (do
-                                              (output/error "Error in reporter: " (ex-data e) " when processing " (:type m))
+                                              (output/error "Error in reporter: " (ex-data e) " when processing " (pr-str (util/minimal-test-event m)))
                                               (stacktrace/print-cause-trace e))))
                                         (catch Throwable t
-                                          (output/error "Error in reporter: " (.getClass t) " when processing " (:type m))
+                                          (output/error "Error in reporter: " (.getClass t) " when processing " (pr-str (util/minimal-test-event m)))
                                           (stacktrace/print-cause-trace t))))))
 
    (catch :kaocha/reporter-not-found {:kaocha/keys [reporter-not-found]}
@@ -101,7 +102,7 @@
                 (when-not (some #(or (hierarchy/leaf? %)
                                      (::testable/load-error %))
                                 (testable/test-seq test-plan))
-                   
+
                   (output/warn (str "No tests were found, make sure :test-paths and "
                                     ":ns-patterns are configured correctly in tests.edn."))
                   (throw+ {:kaocha/early-exit 0 }))

--- a/src/kaocha/plugin/profiling.clj
+++ b/src/kaocha/plugin/profiling.clj
@@ -44,7 +44,7 @@
     (when (::profiling? result)
       (let [tests     (->> result
                            testable/test-seq
-                           (remove :kaocha.test-plan/load-error)
+                           (remove ::testable/load-error)
                            (remove ::testable/skip))
             types     (group-by :kaocha.testable/type tests)
             total-dur (::duration result)

--- a/src/kaocha/report.clj
+++ b/src/kaocha/report.clj
@@ -89,18 +89,19 @@
   (kaocha.hierarchy/derive! :mismatch :kaocha/fail-type)
   ```"
   (:refer-clojure :exclude [symbol])
-  (:require [kaocha.core-ext :refer :all]
+  (:require [clojure.string :as str]
+            [clojure.test :as t]
+            [kaocha.core-ext :refer :all]
+            [kaocha.hierarchy :as hierarchy]
+            [kaocha.history :as history]
+            [kaocha.jit :refer [jit]]
             [kaocha.output :as output]
             [kaocha.plugin.capture-output :as capture]
             [kaocha.stacktrace :as stacktrace]
             [kaocha.testable :as testable]
-            [clojure.test :as t]
-            [slingshot.slingshot :refer [throw+]]
-            [clojure.string :as str]
-            [kaocha.history :as history]
             [kaocha.testable :as testable]
-            [kaocha.hierarchy :as hierarchy]
-            [kaocha.jit :refer [jit]]))
+            [kaocha.util :as util]
+            [slingshot.slingshot :refer [throw+]]))
 
 (defonce clojure-test-report t/report)
 
@@ -414,19 +415,7 @@
 
 (defn debug [m]
   (t/with-test-out
-    (prn (cond-> (select-keys m [:type
-                                 :file
-                                 :line
-                                 :var
-                                 :ns
-                                 :expected
-                                 :actual
-                                 :message
-                                 :kaocha/testable
-                                 :debug
-                                 ::printed-expression])
-           (:kaocha/testable m)
-           (update :kaocha/testable select-keys [:kaocha.testable/id :kaocha.testable/type])))))
+    (prn (util/minimal-test-event m))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -2,28 +2,22 @@
 (ns kaocha.runner
   "Main entry point for command line use."
   (:gen-class)
-  (:require [kaocha.api :as api]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
             [clojure.pprint :as pprint]
             [clojure.set :as set]
             [clojure.spec.alpha :as spec]
             [clojure.string :as str]
             [clojure.tools.cli :as cli]
             [expound.alpha :as expound]
+            [kaocha.api :as api]
             [kaocha.config :as config]
             [kaocha.jit :refer [jit]]
             [kaocha.output :as output]
             [kaocha.plugin :as plugin]
             [kaocha.result :as result]
             [kaocha.specs :as specs]
-            [orchestra.spec.test :as orchestra]
-            [slingshot.slingshot :refer [try+ throw+]])
-  (:import [java.io File]))
-
-(orchestra/instrument
- (filter #(or (str/starts-with? (str %) "kaocha.")
-              (str/starts-with? (str %) "lambdaisland."))
-         (map ns-name (all-ns))))
+            [slingshot.slingshot :refer [throw+ try+]])
+  (:import java.io.File))
 
 (defn- accumulate [m k v]
   (update m k (fnil conj []) v))
@@ -159,17 +153,17 @@
                                                               (config/load-config (if profile
                                                                                     {:profile profile}
                                                                                     {})))
-          _check_config_file                              (when (not (. (File. (or config-file "tests.edn")) exists)) 
-                                                            (output/warn (format (str "Did not load a configuration file and using the defaults.\n" 
+          _check_config_file                              (when (not (. (File. (or config-file "tests.edn")) exists))
+                                                            (output/warn (format (str "Did not load a configuration file and using the defaults.\n"
                                                                                       "This is fine for experimenting, but for long-term use, we recommend creating a configuration file to avoid changes in behavior between releases.\n"
                                                                                       "To create a configuration file using the current defaults, create a file named tests.edn that contains '#%s {}'.")
                                                                                  config/current-reader)))
-          _check                                         (try 
+          _check                                         (try
                                                            (specs/assert-spec :kaocha/config config)
-                                                           (catch AssertionError e 
-                                                             (output/error "Invalid configuration file:\n" 
+                                                           (catch AssertionError e
+                                                             (output/error "Invalid configuration file:\n"
                                                                            (.getMessage e))
-                                                             (throw+ {:kaocha/early-exit 252}))) 
+                                                             (throw+ {:kaocha/early-exit 252})))
           plugin-chain                                    (plugin/load-all (concat (:kaocha/plugins config) plugin))
           cli-options                                     (plugin/run-hook* plugin-chain :kaocha.hooks/cli-options cli-options)
 

--- a/src/kaocha/specs.clj
+++ b/src/kaocha/specs.clj
@@ -85,11 +85,11 @@
                                            (s/keys :req []
                                                    :opt [:kaocha.testable/desc
                                                          :kaocha.test-plan/tests
-                                                         :kaocha.test-plan/load-error])))
+                                                         :kaocha.testable/load-error])))
 
-(s/def :kaocha.test-plan/load-error (s-with-gen
-                                     #(instance? Throwable %)
-                                     #(s-gen #{(ex-info "load error" {:oops "not good"})})))
+(s/def :kaocha.testable/load-error (s-with-gen
+                                    #(instance? Throwable %)
+                                    #(s-gen #{(ex-info "load error" {:oops "not good"})})))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; result

--- a/src/kaocha/testable.clj
+++ b/src/kaocha/testable.clj
@@ -1,16 +1,17 @@
 (ns kaocha.testable
   (:refer-clojure :exclude [load])
-  (:require [clojure.spec.alpha :as s]
-            [kaocha.specs :refer [assert-spec]]
-            [kaocha.history :as history]
-            [kaocha.result :as result]
-            [kaocha.plugin :as plugin]
+  (:require [clojure.java.io :as io]
             [clojure.pprint :as pprint]
-            [clojure.java.io :as io]
-            [kaocha.output :as output]
-            [kaocha.classpath :as classpath]
+            [clojure.spec.alpha :as s]
             [clojure.test :as t]
-            [kaocha.hierarchy :as hierarchy])
+            [kaocha.classpath :as classpath]
+            [kaocha.hierarchy :as hierarchy]
+            [kaocha.history :as history]
+            [kaocha.output :as output]
+            [kaocha.plugin :as plugin]
+            [kaocha.result :as result]
+            [kaocha.specs :refer [assert-spec]]
+            [kaocha.util :as util])
   (:import [clojure.lang Compiler$CompilerException]))
 
 (def ^:dynamic *fail-fast?*

--- a/src/kaocha/type/ns.clj
+++ b/src/kaocha/type/ns.clj
@@ -55,18 +55,14 @@
   (let [do-report #(t/do-report (merge {:ns (:kaocha.ns/ns testable)} %))]
     (type/with-report-counters
       (do-report {:type :begin-test-ns})
-      (if-let [testable (testable/handle-load-error testable)]
-        (do
-          (do-report {:type :end-test-ns})
-          testable)
-        (let [ns-meta         (:kaocha.testable/meta testable)
-              once-fixture-fn (t/join-fixtures (::t/once-fixtures ns-meta))
-              tests           (run-tests testable test-plan once-fixture-fn)
-              result          (assoc (dissoc testable :kaocha.test-plan/tests)
-                                :kaocha.result/tests
-                                tests)]
-          (do-report {:type :end-test-ns})
-          result)))))
+      (let [ns-meta         (:kaocha.testable/meta testable)
+            once-fixture-fn (t/join-fixtures (::t/once-fixtures ns-meta))
+            tests           (run-tests testable test-plan once-fixture-fn)
+            result          (assoc (dissoc testable :kaocha.test-plan/tests)
+                                   :kaocha.result/tests
+                                   tests)]
+        (do-report {:type :end-test-ns})
+        result))))
 
 (s/def :kaocha.type/ns (s/keys :req [:kaocha.testable/type
                                      :kaocha.testable/id

--- a/src/kaocha/type/spec/test/ns.clj
+++ b/src/kaocha/type/spec/test/ns.clj
@@ -44,16 +44,12 @@
   (let [do-report #(t/do-report (merge {:ns (:kaocha.ns/ns testable)} %))]
     (type/with-report-counters
       (do-report {:type :kaocha.stc/begin-ns})
-      (if-let [testable (testable/handle-load-error testable)]
-        (do
-          (do-report {:type :kaocha.stc/end-ns})
-          testable)
-        (let [tests  (testable/run-testables (:kaocha.test-plan/tests testable) test-plan)
-              result (-> testable
-                         (dissoc :kaocha.test-plan/tests)
-                         (assoc :kaocha.result/tests tests))]
-          (do-report {:type :kaocha.stc/end-ns})
-          result)))))
+      (let [tests  (testable/run-testables (:kaocha.test-plan/tests testable) test-plan)
+            result (-> testable
+                       (dissoc :kaocha.test-plan/tests)
+                       (assoc :kaocha.result/tests tests))]
+        (do-report {:type :kaocha.stc/end-ns})
+        result))))
 
 (s/def :kaocha.type/spec.test.ns (s/keys :req [:kaocha.testable/type
                                                :kaocha.testable/id

--- a/src/kaocha/util.clj
+++ b/src/kaocha/util.clj
@@ -1,0 +1,45 @@
+(ns kaocha.util)
+
+(defn lib-path
+  "Returns the path for a lib"
+  ^String [lib ext]
+  (str
+   (.. (name lib)
+       (replace \- \_)
+       (replace \. \/))
+   "." ext))
+
+(defn ns-file
+  "Find the file for a given namespace (symbol), tries to mimic the resolution
+  logic of [[clojure.core/load]]."
+  [ns-sym]
+  (some
+   #(.getResource (clojure.lang.RT/baseLoader) (lib-path ns-sym %))
+   ["class" "cljc" "clj"]))
+
+(defn compiler-exception-file-and-line
+  "Try to get the file and line number from a CompilerException"
+  [^Throwable error]
+  (if (instance? clojure.lang.Compiler$CompilerException error)
+    [(.-source ^clojure.lang.Compiler$CompilerException error)
+     (.-line ^clojure.lang.Compiler$CompilerException error)]
+    (when-let [error (.getCause error)]
+      (recur error))))
+
+(defn minimal-test-event
+  "Return a reduced version of a test event map, so debug output doesn't blow up
+  too much, e.g. in case of deeply nested testables in there."
+  [m]
+  (cond-> (select-keys m [:type
+                          :file
+                          :line
+                          :var
+                          :ns
+                          :expected
+                          :actual
+                          :message
+                          :kaocha/testable
+                          :debug
+                          ::printed-expression])
+    (:kaocha/testable m)
+    (update :kaocha/testable select-keys [:kaocha.testable/id :kaocha.testable/type])))

--- a/test/features/plugins/orchestra_plugin.feature
+++ b/test/features/plugins/orchestra_plugin.feature
@@ -50,6 +50,8 @@ Feature: Orchestra (spec instrumentation)
 
     -- Spec failed --------------------
 
+    Return value
+
       "x"
 
     should satisfy

--- a/test/shared/kaocha/integration_helpers.clj
+++ b/test/shared/kaocha/integration_helpers.clj
@@ -67,7 +67,8 @@
       (with-print-namespace-maps false
         (clojure.pprint/pprint {:deps {'lambdaisland/kaocha           {:local/root (project-dir-path)}
                                        'lambdaisland/kaocha-cloverage {:mvn/version "RELEASE"}
-                                       'org.clojure/test.check        {:mvn/version "0.10.0-alpha3"}}})))))
+                                       'org.clojure/test.check        {:mvn/version "0.10.0-alpha3"}
+                                       'orchestra/orchestra           {:mvn/version "2020.07.12-1"}}})))))
 
 (defn test-dir-setup [m]
   (if (:dir m)

--- a/test/shared/kaocha/test_helper.clj
+++ b/test/shared/kaocha/test_helper.clj
@@ -10,7 +10,7 @@
             [orchestra.spec.test :as orchestra])
   (:import [clojure.lang ExceptionInfo]))
 
-(orchestra/instrument)
+(require 'matcher-combinators.clj-test)
 
 (extend-protocol mc.core/Matcher
   clojure.lang.Var

--- a/tests.edn
+++ b/tests.edn
@@ -1,34 +1,21 @@
 #kaocha/v1
 {:plugins [:kaocha.plugin.alpha/info
-           :kaocha.plugin.alpha/spec-test-check
-           :kaocha.plugin/orchestra
            :profiling
            :print-invocations
            :hooks
            :notifier]
 
- :tests   [{:id         :unit
-            :test-paths ["test/shared"
-                         "test/unit"]}
-           {:id                  :integration
-            :type                :kaocha.type/cucumber
-            :test-paths          ["test/shared"
-                                  "test/features"]
-            :cucumber/glue-paths ["test/step_definitions"]}]
+ :tests [{:id         :unit
+          :test-paths ["test/shared"
+                       "test/unit"]}
+         {:id                  :integration
+          :type                :kaocha.type/cucumber
+          :test-paths          ["test/shared"
+                                "test/features"]
+          :cucumber/glue-paths ["test/step_definitions"]}]
 
  :kaocha.hooks/pre-load [kaocha.assertions/load-assertions]
 
  :kaocha/bindings {kaocha.stacktrace/*stacktrace-filters* []}
-
- :clojure.spec.test.check/instrument? true
- :clojure.spec.test.check/check-asserts? true
- :clojure.spec.test.check/opts
- #profile {;; Halving the default opts to prevent CircleCI from killing the test
-           ;; process for lack of output.
-           :ci {:num-tests 50 :max-size 100}
-           ;; Reducing num-tests by two orders of magnitude in local
-           ;; development greatly speeds up iteration time at the expense of
-           ;; possible false negatives.
-           :default {:num-tests 10}}
 
  :reporter kaocha.report/documentation}


### PR DESCRIPTION
This makes kaocha.watch use the mechanisms already available in
`kaocha.testable` to deal with and report load errors. It also does a general
pass of cleaning things up, because we had created a bit of a mess.

`handle-load-error` is gone, the testable implementations should no longer need
this, just let kaocha.testable handle this stuff for you.

It also seems at some point we went from `:kaocha.test-plan/load-error` to
`:kaocha.testable/load-error`, and ended up with a bit of a hodge-podge. It's
surprising things still worked as well as they did. I changed the remaining
test-plan/load-error references to testable/load-error, since that now
dominates, and is IMO also the more intuitive, since we apply these on
individual testables (typically the suite).

I removed the Orchestra instrumentation, and disabled the fdef check plugin. These things get in the way too easily, at this point they are causing us a lot of work without adding much value. I also dropped the (outdated) Orchestra dependency. The orchestra plugin is still there, but going forward people should bring their own Orchestra if they still want to use it.

Other small bits
- fixed a reflection warning in the notifier plugin
- version bumps
- added portal (dev use)
- somewhat more comprehensive error message when the reporter throws (luckily a rare occasion, unless orchestra starts feeding it random bullshit)
- lots of whitespace fixes

Closes #226