### PR TITLE
Bugfix plugin name normalization

### DIFF
--- a/src/kaocha/plugin.clj
+++ b/src/kaocha/plugin.clj
@@ -68,7 +68,7 @@
 
 (defn normalize-name [plugin-name]
   (if (and (simple-keyword? plugin-name)
-           (not (str/includes? "." (name plugin-name))))
+           (not (str/includes? (name plugin-name) ".")))
     ;; Namespaces without a period are not valid, we treat these as
     ;; kaocha.plugin/*
     (keyword "kaocha.plugin" (name plugin-name))

--- a/test/unit/kaocha/plugin_test.clj
+++ b/test/unit/kaocha/plugin_test.clj
@@ -44,3 +44,10 @@
                  (plugin/load-all [:kaocha/plugin])
                  (catch ExceptionInfo e
                    nil))))))))
+
+(deftest normalize-name-test
+  (are [input expected] (= expected (plugin/normalize-name input))
+    :abc               :kaocha.plugin/abc
+    :kaocha.plugin/abc :kaocha.plugin/abc
+    :custom-ns/abc     :custom-ns/abc
+    :custom.ns.abc     :custom.ns.abc))


### PR DESCRIPTION
fixes lambdaisland/kaocha#235.

Can be considered a breaking change; previously `:a.b.c` would be normalized to `:kaocha.plugin/a.b.c`

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
