### PR TITLE
Add namespace to usages of require.

### DIFF
--- a/src/kaocha/api.clj
+++ b/src/kaocha/api.clj
@@ -1,4 +1,4 @@
-(require 'kaocha.version-check)
+(clojure.core/require 'kaocha.version-check)
 (ns kaocha.api
   "Programmable test runner interface."
   (:require [clojure.test :as t]

--- a/src/kaocha/plugin.clj
+++ b/src/kaocha/plugin.clj
@@ -1,4 +1,4 @@
-(require 'kaocha.version-check)
+(clojure.core/require 'kaocha.version-check)
 (ns kaocha.plugin
   (:require [kaocha.output :as output]
             [clojure.string :as str]

--- a/src/kaocha/repl.clj
+++ b/src/kaocha/repl.clj
@@ -1,4 +1,4 @@
-(require 'kaocha.version-check)
+(clojure.core/require 'kaocha.version-check)
 (ns ^{:author "Arne Brasseur"
       :doc "REPL interface to Kaocha
 

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -1,4 +1,4 @@
-(require 'kaocha.version-check)
+(clojure.core/require 'kaocha.version-check)
 (ns kaocha.runner
   "Main entry point for command line use."
   (:gen-class)


### PR DESCRIPTION
Attempted fix of #239. It appears that, in some cases, a Clojure file can be loaded before clojure.core is required,
so calling require before ns causes issues.