### PR TITLE
Feature: tools-deps exec-fn support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Added
+
+- `kaocha.runner/exec` for use with Clojure CLI's -X feature
+
 # 1.0.887 (2021-09-01 / 38470aa)
 
 ## Added

--- a/README.md
+++ b/README.md
@@ -102,7 +102,25 @@ Add Kaocha as a dependency, preferably under an alias.
 ;; deps.edn
 {:deps { ,,, }
  :aliases
- {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.887"}}}}}
+ {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.887"}}
+         :exec-fn kaocha.runner/exec
+         :exec-args {}}}}
+```
+
+The `exec-args` map can contain any long-form CLI args as keyword keys.
+Use `true` as the value for args that don't take one, or `false` to get the
+`--no-whatever` equivalent.
+
+For example, this CLI invocation:
+`bin/kaocha --config-file my-tests.edn --diff-style :deep --fail-fast --no-color`
+
+...would look like this as an `exec-args` map:
+
+``` clojure
+{:config-file "my-tests.edn"
+ :diff-style  :deep
+ :fail-fast   true
+ :color       false}
 ```
 
 Add a binstub called `bin/kaocha`
@@ -110,7 +128,7 @@ Add a binstub called `bin/kaocha`
 ```
 mkdir -p bin
 echo '#!/usr/bin/env sh' > bin/kaocha
-echo 'clojure -A:test -m kaocha.runner "$@"' >> bin/kaocha
+echo 'clojure -X:test "$@"' >> bin/kaocha
 chmod +x bin/kaocha
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,26 @@ Add Kaocha as a dependency, preferably under an alias.
 ;; deps.edn
 {:deps { ,,, }
  :aliases
+ {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.887"}}}}}
+```
+
+Add a binstub called `bin/kaocha`
+
+```
+mkdir -p bin
+echo '#!/usr/bin/env sh' > bin/kaocha
+echo 'clojure -A:test -m kaocha.runner "$@"' >> bin/kaocha
+chmod +x bin/kaocha
+```
+
+#### tools-deps :exec-fn alternative
+
+If you prefer to use the :exec-fn / -X approach, you can setup kaocha this way:
+
+```clojure
+;; deps.edn
+{:deps { ,,, }
+ :aliases 
  {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.887"}}
          :exec-fn kaocha.runner/exec
          :exec-args {}}}}
@@ -123,14 +143,7 @@ For example, this CLI invocation:
  :color       false}
 ```
 
-Add a binstub called `bin/kaocha`
-
-```
-mkdir -p bin
-echo '#!/usr/bin/env sh' > bin/kaocha
-echo 'clojure -X:test "$@"' >> bin/kaocha
-chmod +x bin/kaocha
-```
+And then kaocha can be invoked this way: `clojure -X:test`
 
 ### Leiningen
 

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -187,3 +187,27 @@
    (System/exit (apply -main* args))
    (catch :kaocha/early-exit {exit-code :kaocha/early-exit}
      (System/exit exit-code))))
+
+(defn- map-key->arg [k & [prefix]]
+  (->> k name (str "--" (when prefix (str prefix "-")))))
+
+(defn exec-args->cli-args
+  [args]
+  (->> args
+       (reduce-kv (fn [o k v]
+                    (let [[arg val] (cond
+                                      (false? v) [(map-key->arg k "no") nil]
+                                      (true? v) [(map-key->arg k) nil]
+                                      :else [(map-key->arg k) (str v)])]
+                      (conj o arg val)))
+                  [])
+       (remove nil?)))
+
+(defn exec
+  "Entrypoint for Clojure CLI's -X feature; converts the arg map into a
+  clojure.tools.cli args list. Assumes the arg map in deps.edn is composed of
+  long-form args as keyword keys. For args with no values (e.g. --fail-fast),
+  use the value true. If you set these to false, they will be transformed into
+  --no-whatever args."
+  [args]
+  (apply -main (exec-args->cli-args args)))

--- a/test/unit/kaocha/runner_test.clj
+++ b/test/unit/kaocha/runner_test.clj
@@ -21,3 +21,19 @@
       (is (= -1 result))
       (is (re-find #"Unknown option: \"--foo\"\n" out))
       (is (re-find #"USAGE:" out)))))
+
+(deftest exec-args->cli-args-test
+  (testing "converts exec-args map to CLI args vector w/ values after arg-names"
+    (let [cli-args (runner/exec-args->cli-args {:config-file "tests.edn"
+                                                :fail-fast   true
+                                                :color       false
+                                                :diff-style  :deep})]
+      (are [arg-name arg-val]
+        (let [arg-index (.indexOf cli-args arg-name)]
+          (and (<= 0 arg-index)
+               (or (= ::no-val arg-val)
+                   (= (inc arg-index) (.indexOf cli-args arg-val)))))
+        "--config-file" "tests.edn"
+        "--fail-fast"   ::no-val
+        "--no-color"    ::no-val
+        "--diff-style"  ":deep"))))


### PR DESCRIPTION
I added a new `kaocha.runner/exec` entrypoint to allow usage from tools-dep's new -X feature. All it does is convert the `:exec-args` map to a list of CLI args and passes that to the existing `-main`.

This has the nice side effect of allowing you to load the `:test` alias in a REPL without either a) running all of your tests on load if you have a `:main-opts` directly in your alias map or b) requiring that you have a separate wrapper script that specifies the main ns to invoke to avoid a. But of course you can still have a wrapper script if you like. :)

Quick and dirty (too quick and dirty?) :)