### PR TITLE
Add exec fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Unreleased
 
 ## Added
+- `kaocha.runner/exec` for use with Clojure CLI's -X feature
 
 ## Fixed
 
 - Fix only considering public vars when building up the test plan
+=======
 
 # 1.0.887 (2021-09-01 / 38470aa)
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,51 @@ echo 'boot kaocha "$@"' >> bin/kaocha
 chmod +x bin/kaocha
 ```
 
+#### Clojure CLI (tools.deps) :exec-fn alternative
+
+We also support using the Clojure CLI `:exec-fn`/`-X`. However, we recommend the
+binstub approach above because it allows you to use traditional long and short
+options.  If you nonetheless prefer `:exec-fn`/`-X`, you can set up `deps.edn`:
+
+```clojure
+;; deps.edn
+{:deps { ,,, }
+ :aliases 
+ {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.887"}}
+         :exec-fn kaocha.runner/exec
+         :exec-args {}}}}
+```
+
+And then Kaocha can be invoked this way: `clojure -X:test`
+
+Generally speaking, we recommend using `tests.edn` for all of your configuration
+rather than putting it in `exec-args` unless there's an alternative combination
+of options you frequently run.
+
+In that case, you can put configuration options `:exec-args` as though it were
+`tests.edn`. Let's say you frequently use watch with `:fail-fast` and a subset
+of tests skipped. You could save that configuration with an additional alias:
+`clojure -X:watch-test` like so:
+
+
+```clojure
+;; deps.edn
+{:deps { ,,, }
+ :aliases 
+ {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.887"}}
+         :exec-fn kaocha.runner/exec
+         :exec-args {}}
+ :watch-test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.887"}}
+         :exec-fn kaocha.runner/exec
+         :exec-args {:watch? true
+	 :skip-meta :slow
+	 :fail-fast? true }}}}
+```
+
+If you wanted to turn off `fail-fast` temporarily, you could run `clojure
+-X:watch-test :fail-fast? false`
+
+
 ### All tools
 
 By default, Kaocha assumes that:

--- a/doc/02_installing.md
+++ b/doc/02_installing.md
@@ -82,7 +82,7 @@ options.  If you nonetheless prefer `:exec-fn`/`-X`, you can set up `deps.edn`:
 {:deps { ,,, }
  :aliases 
  {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.887"}}
-         :exec-fn kaocha.runner/exec
+         :exec-fn kaocha.runner/exec-fn
          :exec-args {}}}}
 ```
 
@@ -103,7 +103,7 @@ of tests skipped. You could save that configuration with an additional alias:
 {:deps { ,,, }
  :aliases 
  {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.887"}}
-         :exec-fn kaocha.runner/exec
+         :exec-fn kaocha.runner/exec-fn
          :exec-args {}}
  :watch-test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.887"}}
          :exec-fn kaocha.runner/exec

--- a/doc/02_installing.md
+++ b/doc/02_installing.md
@@ -71,6 +71,50 @@ Now you can invoke Kaocha as such:
 bin/kaocha --version
 ```
 
+#### Alternative method: :exec-fn
+
+We also support using the Clojure CLI `:exec-fn`/`-X`. However, we recommend the
+binstub approach above because it allows you to use traditional long and short
+options.  If you nonetheless prefer `:exec-fn`/`-X`, you can set up `deps.edn`:
+
+```clojure
+;; deps.edn
+{:deps { ,,, }
+ :aliases 
+ {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.887"}}
+         :exec-fn kaocha.runner/exec
+         :exec-args {}}}}
+```
+
+And then Kaocha can be invoked this way: `clojure -X:test`
+
+Generally speaking, we recommend using `tests.edn` for all of your configuration
+rather than putting it in `exec-args` unless there's an alternative combination
+of options you frequently run.
+
+In that case, you can put configuration options `:exec-args` as though it were
+`tests.edn`. Let's say you frequently use watch with `:fail-fast` and a subset
+of tests skipped. You could save that configuration with an additional alias:
+`clojure -X:watch-test` like so:
+
+
+```clojure
+;; deps.edn
+{:deps { ,,, }
+ :aliases 
+ {:test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.887"}}
+         :exec-fn kaocha.runner/exec
+         :exec-args {}}
+ :watch-test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0.887"}}
+         :exec-fn kaocha.runner/exec
+         :exec-args {:watch? true
+	 :skip-meta :slow
+	 :fail-fast? true }}}}
+```
+
+If you wanted to turn off `fail-fast` temporarily, you could run `clojure
+-X:watch-test :fail-fast? false`.
+
 ### Leiningen
 
 Add Kaocha to your `:dev` profile, then add an alias that invokes `lein run -m kaocha.runner`:


### PR DESCRIPTION
Adds an entry point for using Kaocha with the `exec-fn`/`-X` feature of Clojure CLI tools.

While my name's on the commit, @plexus wrote the code and @cap10morgan wrote the basis of the documentation and tests. Thanks!