### PR TITLE
Fix several tests for Clojure 1.11

### DIFF
--- a/test/unit/kaocha/api_test.clj
+++ b/test/unit/kaocha/api_test.clj
@@ -1,5 +1,5 @@
 (ns kaocha.api-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [testing is deftest]]
             [kaocha.api :refer :all]
             [kaocha.test-util :refer [with-out-err]]
             [slingshot.slingshot :refer [try+]]))

--- a/test/unit/kaocha/type/clojure/test_test.clj
+++ b/test/unit/kaocha/type/clojure/test_test.clj
@@ -1,6 +1,6 @@
 (ns kaocha.type.clojure.test-test
   (:refer-clojure :exclude [symbol])
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [is deftest]]
             [kaocha.core-ext :refer :all]
             [kaocha.testable :as testable]
             [kaocha.test-util :refer [with-test-ctx]]))

--- a/test/unit/kaocha/type/ns_test.clj
+++ b/test/unit/kaocha/type/ns_test.clj
@@ -1,6 +1,6 @@
 (ns kaocha.type.ns-test
   (:refer-clojure :exclude [symbol])
-  (:require [clojure.test :as t :refer :all]
+  (:require [clojure.test :as t :refer [is deftest]]
             [kaocha.core-ext :refer :all]
             [kaocha.testable :as testable]
             [kaocha.test-helper]

--- a/test/unit/kaocha/type/var_test.clj
+++ b/test/unit/kaocha/type/var_test.clj
@@ -1,6 +1,6 @@
 (ns kaocha.type.var-test
   (:refer-clojure :exclude [symbol])
-  (:require [clojure.test :as t :refer :all]
+  (:require [clojure.test :as t :refer [testing is deftest]]
             [kaocha.test-factories :as f]
             [kaocha.testable :as testable]
             [kaocha.report :as report]


### PR DESCRIPTION
Fixes #252.

Clojure 1.11 add the function run-test, which conflicted with a test in several namespaces.
This changes the :refer :all to be specific to the symbols we actually need.