### PR TITLE
Apply bindings higher in the stack, check if history var is bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,34 @@
 # Unreleased
 
-## Added
-
 ## Fixed
 
-## Changed
+- Apply `:kaocha/bindings` higher in the stack, so they are visible to `main`
+  and `post-summary` plugin hooks
+- Fix an issue when the history track reporter gets invoked outside of the scope
+  where the history tracking atom is bound
 
 # 1.0.937 (2021-10-20 / 8ccaba7)
 
 ## Added
+
 - `kaocha.runner/exec` for use with Clojure CLI's -X feature
 - Added `gc-profiling` plugin for measuring the memory usage of tests.
 
 ## Fixed
 
 - Breaking! Unqualified plugin names containing dots are no longer
-    normalized to contain the `kaocha.plugin`-namespace in front.
+  normalized to contain the `kaocha.plugin`-namespace in front.
 
 # 1.0.902 (2021-10-01 / 3100c8b)
 
 ## Added
 
 - Added support for code using `:as-alias`
-
 - New `gc-profiling` plugin for measuring tests' memory usage.
 
 ## Fixed
 
 - Fix only considering public vars when building up the test plan
-=======
 
 # 1.0.887 (2021-09-01 / 38470aa)
 

--- a/src/kaocha/history.clj
+++ b/src/kaocha/history.clj
@@ -6,7 +6,9 @@
 
 (defmulti track :type :hierarchy #'hierarchy/hierarchy)
 
-(defmethod track :default [m] (swap! *history* conj m))
+(defmethod track :default [m]
+  (when *history*
+    (swap! *history* conj m)))
 
 (defmethod track :kaocha/fail-type [m]
   (swap! *history* conj (assoc m

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -60,23 +60,6 @@
    [nil "--help"                "Display this help message."]
    ["-H" "--test-help"          "Display this help message."]])
 
-
-(defn exec-fn
-  "Entry point for use with deps.tools' -X feature."
-  [m]
-  (try+
-   (let [config (-> (config/load-config)
-                    (config/merge-config (config/normalize m)))]
-     (plugin/with-plugins (plugin/load-all (:kaocha/plugins config))
-       (let [config (plugin/run-hook :kaocha.hooks/config config)]
-         (plugin/run-hook :kaocha.hooks/main config)
-         (let [result (plugin/run-hook :kaocha.hooks/post-summary (api/run config))
-               totals (result/totals (:kaocha.result/tests result))
-               exit-code (min (+ (:kaocha.result/error totals) (:kaocha.result/fail totals)) 255)]
-           (System/exit exit-code)))))
-   (catch :kaocha/early-exit {exit-code :kaocha/early-exit}
-     (System/exit exit-code))))
-
 (defn load-props [file-name]
   (with-open [^java.io.Reader reader (io/reader file-name)]
     (let [props (java.util.Properties.)]
@@ -144,7 +127,7 @@
         (min (+ (:kaocha.result/error totals) (:kaocha.result/fail totals)) 255))
 
       :else
-      (do
+      (with-bindings (config/binding-map config)
         (plugin/run-hook :kaocha.hooks/main config)
         (let [result (plugin/run-hook :kaocha.hooks/post-summary (api/run config))
               totals (result/totals (:kaocha.result/tests result))]
@@ -202,5 +185,22 @@
 (defn -main [& args]
   (try+
    (System/exit (apply -main* args))
+   (catch :kaocha/early-exit {exit-code :kaocha/early-exit}
+     (System/exit exit-code))))
+
+(defn exec-fn
+  "Entry point for use with deps.tools' -X feature."
+  [m]
+  (try+
+   (let [config (-> (config/load-config)
+                    (config/merge-config (config/normalize m)))]
+     (plugin/with-plugins (plugin/load-all (:kaocha/plugins config))
+       (let [config (plugin/run-hook :kaocha.hooks/config config)]
+         (with-bindings (config/binding-map config)
+           (plugin/run-hook :kaocha.hooks/main config)
+           (let [result (plugin/run-hook :kaocha.hooks/post-summary (api/run config))
+                 totals (result/totals (:kaocha.result/tests result))
+                 exit-code (min (+ (:kaocha.result/error totals) (:kaocha.result/fail totals)) 255)]
+             (System/exit exit-code))))))
    (catch :kaocha/early-exit {exit-code :kaocha/early-exit}
      (System/exit exit-code))))


### PR DESCRIPTION
Add an extra (with-bindings (config/bindig-map config) ...) at the top level in
kaocha.runner, we add the bindings later in `api/run` as well, and still need to
do that too, in case a plugin modifies the binding map. This new binding
wrapping is useful to influence `:main` and `:post-summary` plugin invocations.

Make the defaults `history/track` implementation more defensive, so it doesn't
throw when called outside the scope where `history/*history*` is bound. This
fixes an unfortunate interaction with spec and test.check.

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
