### PR TITLE
Don't skip tests with load errors

### DIFF
--- a/src/kaocha/api.clj
+++ b/src/kaocha/api.clj
@@ -102,7 +102,6 @@
                 (when-not (some #(or (hierarchy/leaf? %)
                                      (::testable/load-error %))
                                 (testable/test-seq test-plan))
-
                   (output/warn (str "No tests were found, make sure :test-paths and "
                                     ":ns-patterns are configured correctly in tests.edn."))
                   (throw+ {:kaocha/early-exit 0 }))

--- a/src/kaocha/plugin/filter.clj
+++ b/src/kaocha/plugin/filter.clj
@@ -65,7 +65,10 @@
     (cond
       (or (seq focus) (seq focus-meta))
       (cond
-        ;; - postiive
+        (::testable/load-error testable)
+        testable
+
+        ;; - positive
         ;;   - foo ^:a
         ;;   - bar ^:b
         ;; --focus positive --focus-meta a


### PR DESCRIPTION
Currently this leads to an unfortunate interaction where if you `--focus
foo/bar`, but `foo.clj` fails to load, then there is no `#'foo/bar`, and the `foo`
ns gets skipped, even though the `foo` ns actually has a load error which we
need to show the user.

So: never mark testables with load errors as to be skipped, we're better off
being cautious here and always surfacing load-errors.

I just ran into this by getting the dreaded "no tests found" message when using a `--focus` flag. Without the `--focus` I got to see the actual error. This should fix that.

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
