### PR TITLE
Add nextjournal/beholder as an alternative watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 ## Added
 
+- Added configuration `:kaocha.watch/type` which takes either `:beholder` or
+  `:hawk` as values. Defaulting to `:beholder` as the new fs watcher.
+
 ## Fixed
 
 ## Changed
+
+- Changed default watcher to [Beholder](https://github.com/nextjournal/beholder)
+  which supports OSX/m1 machines natively. Hawk is now deprecated and will be
+  removed in a future release.
 
 # 1.60.977 (2022-01-01 / 4a6ed21)
 

--- a/deps.edn
+++ b/deps.edn
@@ -9,6 +9,7 @@
   org.tcrawley/dynapath        {:mvn/version "1.1.0"}
   slingshot/slingshot          {:mvn/version "0.12.2"}
   hawk/hawk                    {:mvn/version "0.2.11"}
+  com.nextjournal/beholder     {:mvn/version "1.0.0"}
   expound/expound              {:mvn/version "0.8.10"}
   aero/aero                    {:mvn/version "1.1.6"}
   progrock/progrock            {:mvn/version "0.1.2"}

--- a/doc/07_watch_mode.md
+++ b/doc/07_watch_mode.md
@@ -84,7 +84,7 @@ Kaocha uses [Beholder](https://github.com/nextjournal/beholder) to watch the
 filesystem for changes. By default Beholder will pick a mechanism suitable for
 your operating system. Beholder works with OSX and M1 mac machines as well.
 
-Previously Kaocha used another watcher [Hawk](https://github.com/wkf/hawk) which
+Previously Kaocha used another watcher, [Hawk](https://github.com/wkf/hawk), which
 has been deprecated in favour of Beholder. If you still want to use it for some
 reason then use the `:kaocha.watch/type :hawk` configuration to switch to hawk.
 Please note that Hawk will be removed completely in a future release.

--- a/doc/07_watch_mode.md
+++ b/doc/07_watch_mode.md
@@ -80,17 +80,15 @@ Currently these features of `.gitignore` are not supported:
 
 ## Configuring the watcher
 
-Kaocha uses [Hawk](https://github.com/wkf/hawk) to watch the filesystem for
-changes. By default Hawk will pick a mechanism suitable for your operating
-system, but if that doesn't cut it for some reason you can switch to using
-polling instead.
+Kaocha uses [Beholder](https://github.com/nextjournal/beholder) to watch the
+filesystem for changes. By default Beholder will pick a mechanism suitable for
+your operating system. Beholder works with OSX and M1 mac machines as well.
+
+Previously Kaocha used another watcher [Hawk](https://github.com/wkf/hawk) which
+has been deprecated in favour of Beholder. If you still want to use it for some
+reason then use the `:kaocha.watch/type :hawk` configuration to switch to hawk.
+Please note that Hawk will be removed completely in a future release.
 
 Use the `:kaocha.watch/hawk-opts` configuration key to pass options to Hawk.
 Currently it understands `:watcher` (`:java`, `:barbary`, `:polling`) and
 `:sensitivity` (`:high`, `:medium`, `:low`, only applies to `:polling`).
-
-```
-#kaocha/v1
-{:kaocha.watch/hawk-opts {:watcher :polling
-                          :sensitivity :medium}}
-```

--- a/doc/07_watch_mode.md
+++ b/doc/07_watch_mode.md
@@ -86,7 +86,7 @@ your operating system. Beholder works with OSX and M1 mac machines as well.
 
 Previously Kaocha used another watcher, [Hawk](https://github.com/wkf/hawk), which
 has been deprecated in favour of Beholder. If you still want to use it for some
-reason then use the `:kaocha.watch/type :hawk` configuration to switch to hawk.
+reason, then use the `:kaocha.watch/type :hawk` configuration to switch to Hawk.
 Please note that Hawk will be removed completely in a future release.
 
 Use the `:kaocha.watch/hawk-opts` configuration key to pass options to Hawk.

--- a/src/kaocha/watch.clj
+++ b/src/kaocha/watch.clj
@@ -283,7 +283,7 @@ errors as test errors."
   (let [watcher-type (::type config :beholder)
         watcher-opts (condp = watcher-type
                        :hawk (::hawk-opts config {})
-                       :beholder (::beholder-opts config {})
+                       :beholder {} ;; beholder does not take opts
                        {})
         watch-paths (if (:kaocha.watch/use-ignore-file config)
                       (set/union (watch-paths config)

--- a/src/kaocha/watch.clj
+++ b/src/kaocha/watch.clj
@@ -22,7 +22,8 @@
             [lambdaisland.tools.namespace.file :as ctn-file]
             [lambdaisland.tools.namespace.parse :as ctn-parse]
             [lambdaisland.tools.namespace.reload :as ctn-reload]
-            [lambdaisland.tools.namespace.track :as ctn-track])
+            [lambdaisland.tools.namespace.track :as ctn-track]
+            [nextjournal.beholder :as beholder])
   (:import [java.nio.file FileSystems]
            [java.util.concurrent ArrayBlockingQueue BlockingQueue]))
 
@@ -262,28 +263,47 @@ errors as test errors."
               (map io/file))
         (:kaocha/tests config)))
 
-(defn watch! [q watch-paths hawk-opts]
-  (hawk/watch! hawk-opts
+(defmulti watch! :type)
+
+(defmethod watch! :hawk [{:keys [q watch-paths opts]}]
+  (hawk/watch! opts
                [{:paths   watch-paths
                  :handler (fn [ctx event]
                             (when (= (:kind event) :modify)
                               (qput q (:file event))))}]))
 
+(defmethod watch! :beholder [{:keys [q watch-paths opts]}]
+  (apply beholder/watch
+         (fn [{:keys [type path]}]
+           (when (= type :modify)
+             (qput q path)))
+         (map str watch-paths)))
+
 (defn run* [config finish? q]
-  (let [hawk-opts (::hawk-opts config {})
+  (let [watcher-type (::type config :hawk)
+        watcher-opts (condp = watcher-type
+                       :hawk (::hawk-opts config {})
+                       :beholder (::beholder-opts config {})
+                       {})
         watch-paths (if (:kaocha.watch/use-ignore-file config)
-                     (set/union (watch-paths config)
-                                (set (map #(.getParentFile (.getCanonicalFile %)) (find-ignore-files "."))))
-                     (watch-paths config))
+                      (set/union (watch-paths config)
+                                 (set (map #(.getParentFile (.getCanonicalFile %)) (find-ignore-files "."))))
+                      (watch-paths config))
         tracker     (-> (ctn-track/tracker)
                         (ctn-dir/scan-dirs watch-paths)
                         (dissoc :lambdaisland.tools.namespace.track/unload
                                 :lambdaisland.tools.namespace.track/load))]
 
-    (watch! q watch-paths hawk-opts)
+    (watch! {:type watcher-type
+             :q q
+             :watch-paths watch-paths
+             :opts watcher-opts})
     (when-let [config-file (get-in config [:kaocha/cli-options :config-file])]
       (when (.exists (io/file config-file))
-        (watch! q #{config-file} hawk-opts)))
+        (watch! {:type watcher-type
+                 :q q
+                 :watch-paths #{config-file}
+                 :opts watcher-opts})))
 
     (future
       (let [stdin (io/reader System/in)]

--- a/src/kaocha/watch.clj
+++ b/src/kaocha/watch.clj
@@ -280,7 +280,7 @@ errors as test errors."
          (map str watch-paths)))
 
 (defn run* [config finish? q]
-  (let [watcher-type (::type config :hawk)
+  (let [watcher-type (::type config :beholder)
         watcher-opts (condp = watcher-type
                        :hawk (::hawk-opts config {})
                        :beholder (::beholder-opts config {})
@@ -293,6 +293,9 @@ errors as test errors."
                         (ctn-dir/scan-dirs watch-paths)
                         (dissoc :lambdaisland.tools.namespace.track/unload
                                 :lambdaisland.tools.namespace.track/load))]
+
+    (when (or (= watcher-type :hawk) (::hawk-opts config))
+      (output/warn "Hawk watcher is deprecated in favour of beholder. Kaocha will soon get rid of hawk completely."))
 
     (watch! {:type watcher-type
              :q q

--- a/src/kaocha/watch.clj
+++ b/src/kaocha/watch.clj
@@ -272,7 +272,7 @@ errors as test errors."
                             (when (= (:kind event) :modify)
                               (qput q (:file event))))}]))
 
-(defmethod watch! :beholder [{:keys [q watch-paths opts]}]
+(defmethod watch! :beholder [{:keys [q watch-paths]}]
   (apply beholder/watch
          (fn [{:keys [type path]}]
            (when (= type :modify)


### PR DESCRIPTION
hawk is using an old version of JNA which breaks file watching on m1 macs.
The alternative was to use :polling or :java but they were either too slow
or consumed lots of battery

[beholder](https://github.com/nextjournal/beholder) seems to be maintained, fast, and a much cleaner approach.

figwheel has also shifted to using beholder instead of hawk. shadow-cljs
also got rid of hawk

maybe beholder should just replace hawk altogether?

- [x] add beholder as default FS
- [x] hawk can be used using a configuration param `:kaocha.watch/type :hawk` but show DEPRECATED warnings
- [x] update docs and changelog

cc: #151 , https://github.com/thheller/shadow-cljs/commit/f3b89b5a3d0f35b78f0be9e457f78a70c0d7bf04 , https://github.com/bhauman/figwheel-main/pull/299