### PR TITLE
Add --no-fail-fast CLI option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added configuration `:kaocha.watch/type` which takes either `:beholder` or
   `:hawk` as values. Defaulting to `:beholder` as the new fs watcher.
+- Add `--no-fail-fast` CLI option
 
 ## Fixed
 

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -117,7 +117,7 @@
 
 (defn apply-cli-opts [config options]
   (cond-> config
-    (some? (:fail-fast options))  (assoc :kaocha/fail-fast? true)
+    (some? (:fail-fast options))  (assoc :kaocha/fail-fast? (:fail-fast options))
     (:reporter options)           (assoc :kaocha/reporter (:reporter options))
     (:watch options)              (assoc :kaocha/watch? (:watch options))
     (some? (:color options))      (assoc :kaocha/color? (:color options))

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -31,7 +31,7 @@
    [nil  "--print-config"       "Print out the fully merged and normalized config, then exit."]
    [nil  "--print-test-plan"    "Load tests, build up a test plan, then print out the test plan and exit."]
    [nil  "--print-result"       "Print the test result map as returned by the Kaocha API."]
-   [nil  "--fail-fast"          "Stop testing after the first failure."]
+   [nil  "--[no-]fail-fast"     "Stop testing after the first failure."]
    [nil  "--[no-]color"         "Enable/disable ANSI color codes in output. Defaults to true."]
    [nil  "--[no-]watch"         "Watch filesystem for changes and re-run tests."]
    [nil  "--reporter SYMBOL"    "Change the test reporter, can be specified multiple times."


### PR DESCRIPTION
This is useful for occasionally overriding the tests.edn setting.