### PR TITLE
Partially fix watch test bug

### DIFF
--- a/test/unit/kaocha/watch_test.clj
+++ b/test/unit/kaocha/watch_test.clj
@@ -123,6 +123,7 @@
 
     (Thread/sleep 100)
     (integration/spit-file m (str "test/" prefix "/bar_test.clj") (str "(ns " prefix ".bar-test (:require [clojure.test :refer :all])) (deftest xxx-test (is (= :xxx :zzz)))"))
+;;(w/qput q (.resolve (:dir m) (str "test/" prefix "/bar_test.clj")))
     (Thread/sleep 100)
     (reset! finish? true)
     (w/qput q :finish)


### PR DESCRIPTION
From the original PR (#64), fixes #190:

>I discovered that the watch-test had an (is a b) type bug - it wasn't verifying its assertion. Kaocha can catch those, can't it? :)
>Anyway, I added in the equals, and further discovered that the test wasn't producing the expected outcome. On my system (OSX) I needed to manually trigger an event to see the second run in the output. The test is still failing though, as I'm not seeing the "Reloading #{foo.bar-test}" part in my test run. I figured maybe you'd catch this more easily than me?

I haven't made any changes besides rebasing it, but I'm not making changes to the original PR for posterity. The key change seems to be Mitesh's addition of the beholder watcher (#268).