### PR TITLE
Fix profiling plugin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Fixed
 
+- Fix issue with `gc-profiling` plugin when there's a syntax error.
+
 ## Changed
 
 # 1.64.1010 (2022-03-17 / e203099)

--- a/src/kaocha/plugin/gc_profiling.clj
+++ b/src/kaocha/plugin/gc_profiling.clj
@@ -69,7 +69,9 @@
                 longest  (->> tests
                               (map :kaocha.testable/id) 
                               (map count)
-                              (reduce (fn [a b] (Math/max a b)))
+                              (reduce (fn  
+                                        ([] nil) ;in case of empty coll
+                                        ([a b] (Math/max a b))))
                               (+ 2)) ;Leave space for identation
                 types     (group-by :kaocha.testable/type tests)
                negative-allocations? (some neg? (remove nil? (map ::delta (testable/test-seq result))))]

--- a/src/kaocha/plugin/gc_profiling.clj
+++ b/src/kaocha/plugin/gc_profiling.clj
@@ -69,9 +69,7 @@
                 longest  (->> tests
                               (map :kaocha.testable/id) 
                               (map count)
-                              (reduce (fn  
-                                        ([] 0) ;in case of empty coll
-                                        ([a b] (Math/max a b))))
+                              (reduce (fn  ([a b] (Math/max a b))) 0)
                               (+ 2)) ;Leave space for identation
                 types     (group-by :kaocha.testable/type tests)
                negative-allocations? (some neg? (remove nil? (map ::delta (testable/test-seq result))))]

--- a/src/kaocha/plugin/gc_profiling.clj
+++ b/src/kaocha/plugin/gc_profiling.clj
@@ -46,7 +46,7 @@
   (post-test [testable _]
     (stop testable))
 
-  (cli-options [opts]
+ (cli-options [opts]
                (conj opts
                      [nil "--[no-]gc-profiling" "Show the approximate memory used by each test."]
                      [nil "--[no-]gc-profiling-individual" "Show the details of individual tests."]))
@@ -70,7 +70,7 @@
                               (map :kaocha.testable/id) 
                               (map count)
                               (reduce (fn  
-                                        ([] nil) ;in case of empty coll
+                                        ([] 0) ;in case of empty coll
                                         ([a b] (Math/max a b))))
                               (+ 2)) ;Leave space for identation
                 types     (group-by :kaocha.testable/type tests)

--- a/src/kaocha/plugin/gc_profiling.clj
+++ b/src/kaocha/plugin/gc_profiling.clj
@@ -47,9 +47,9 @@
     (stop testable))
 
  (cli-options [opts]
-               (conj opts
-                     [nil "--[no-]gc-profiling" "Show the approximate memory used by each test."]
-                     [nil "--[no-]gc-profiling-individual" "Show the details of individual tests."]))
+              (conj opts
+                    [nil "--[no-]gc-profiling" "Show the approximate memory used by each test."]
+                    [nil "--[no-]gc-profiling-individual" "Show the details of individual tests."]))
 
   (config [{:kaocha/keys [cli-options] :as config}]
           (assoc config


### PR DESCRIPTION
Fixes #281. Apparently, syntax errors prevent tests from running, so there's no results to calculate the length of in `post-summary`. I wasn't able to reproduce the original bug directly, but I was able to reproduce the issue with the anonymous function.