### PR TITLE
--watch that only reruns tests affected by loaded changes

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,6 +4,8 @@
  {org.clojure/clojure          {:mvn/version "1.10.3"}
   org.clojure/spec.alpha       {:mvn/version "0.3.218"}
   org.clojure/tools.cli        {:mvn/version "1.0.206"}
+  io.github.nextjournal/clerk {:git/sha "32ef18e12df6cfd2a38c13ccaa9d6fa932fa0fdb"
+                               #_#_:local/root "../clerk"}
   lambdaisland/tools.namespace {:mvn/version "0.1.247"}
   lambdaisland/deep-diff       {:mvn/version "0.0-47"}
   org.tcrawley/dynapath        {:mvn/version "1.1.0"}

--- a/src/kaocha/watch_deps.clj
+++ b/src/kaocha/watch_deps.clj
@@ -1,0 +1,70 @@
+(ns kaocha.watch-deps
+  "Analysis that tracks depedencies between forms + a hash of the forms.
+  Enables calculating which tests need to rerun after a form changes"
+  (:require [nextjournal.clerk.hashing :as hashing]
+            [clojure.set :as set]))
+
+(defn info [file]
+  (let [analyzed-doc (-> file
+                         hashing/parse-file
+                         hashing/build-graph)]
+    (assoc (:graph analyzed-doc) :->hash (->> (hashing/hash analyzed-doc)
+                                              (filter (fn [[k _v]] (symbol? k)))
+                                              (into {})))))
+
+(defn test-vars-for-file [ns]
+  ;; TODO this only works for things like clojure.test; need to find the kaocha
+  ;; way of gettings test vars per ns
+  (into #{}
+        (filter #(-> % meta :test)
+                (vals (ns-interns ns)))))
+
+(defonce !state (atom {:files {}
+                       :test-vars #{}}))
+
+(defn init!
+  "for a map from ns to file-handler, calculate the depedency analysis for each ns"
+  [filemap]
+  (reset! !state
+          (reduce (fn [acc [file ns]]
+                    (let [filepath (str file)]
+                      (-> acc
+                          (update :test-vars #(set/union % (test-vars-for-file ns)))
+                          (assoc-in [:files filepath] (info filepath)))))
+                  {:files {}
+                   :test-vars #{}}
+                  filemap)))
+
+(defn affected-test-symbols [all-test-vars all-deps last-info new-info]
+  (let [all-test-syms (into #{} (map symbol all-test-vars))
+        changed (->> last-info
+                     :->hash
+                     (filter (fn [[k v]] (not= (get-in new-info [:->hash k]) v)))
+                     (map first))]
+    (->> changed
+         (reduce (fn [test-vars changed-var]
+                   (set/union test-vars
+                              (set/intersection all-test-syms
+                                                (get all-deps changed-var))))
+                 #{})
+         (into #{}))))
+
+(defn update-file!
+  "re-analyze a file and return symbols for test variables that are affected by
+  changes"
+  [file ns]
+  (let [filename      (str file)
+        prev-analysis (get-in @!state [:files filename])
+        test-vars     (set/union (test-vars-for-file ns)
+                                 (get @!state :test-vars))
+        new-analysis  (info filename)
+        all-deps      (apply merge-with
+                             set/union
+                             (map (comp :dependents second) (:files @!state)))]
+    (if (= prev-analysis new-analysis)
+      []
+      (do (swap! !state
+                 #(-> %
+                      (assoc :test-vars test-vars)
+                      (assoc-in [:files filename] new-analysis)))
+          (affected-test-symbols test-vars all-deps prev-analysis new-analysis)))))


### PR DESCRIPTION
This is a code sketch of a feature I've been desiring in a test runner:
when in watch mode, only rerun tests that have been affected by loaded changes

## background
I wanted to do a proof-of-concept to prove it was generally possible (hence no tests yet :) ), and now I'm interested in discussing whether this is something kaocha folks would be interested in including. If so, does my general approach look okay (modulo the `TODO`s) or do I need to hook into different parts of the system?

I imagine that it could be a different CLI flag, aside from `--watch` given that it might have (incompleteness) bugs; something like `--watch-with-deps-analysis` (or something shorter if a good name arises)

## behavior

### current
Currently in kaocha, with `--watch`, when a file changes, it is reloaded, along with its corresponding `*_test.clj` friend. Then the entire test suite is re-run. Back when I worked at Nubank this could mean ~1-2 minutes of tests, and hence I never really used `--watch`.
There is the nice case where if tests fail, upon next code reload, those test failures are run first, and only if they pass are the rest of the tests run, which helps with the re-run times of the entire test suite.

### proposed
With the changes in this PR, with `--watch` (or whatever new flag we give the behavior), when the suite runs for the first time it analyzes all loaded namespaces using [Clerk](https://github.com/nextjournal/clerk)'s form hash/dependency analysis and stores the results in an atom. Then when a file changes, it is reloaded, along with its corresponding `*_test.clj` friend. Right after reload, and before the tests are run, we re-analyze the changed namespaces using Clerk. If any forms change (via the calculated hash), we find all test forms that are `dependents` of that changed form and pass them back to kaocha's filtering logic to ensure only they are run.

For example, if I'm running kaocha in some random project like ordnungsamt
```
$ ./bin/kaocha unit --watch

[(........)]
2 tests, 8 assertions, 0 failures.
```
and I change only the [`compose-filters`](https://github.com/nubank/ordnungsamt/blob/eecd4a4ef2983b426b2b2d6d724c6183f888ba5d/src/ordnungsamt/core.clj#L162) def, then only [the test that uses `compose-filters`](https://github.com/nubank/ordnungsamt/blob/eecd4a4ef2983b426b2b2d6d724c6183f888ba5d/test/unit/ordnungsamt/core_test.clj#L16), either directly or indirectly, is re-run:
```
[watch] Reloading #{ordnungsamt.core ordnungsamt.core-test}
[watch] Running tests affected by changes #{ordnungsamt.core-test/test-compose-filters}
[(.....)]
1 tests, 5 assertions, 0 failures.
```

### midje test runner
I used to use Midje a lot and got used to the way it did watching and test auto rerunning.
It wouldn't re-run the entire test suite on reloads, but rather only tests for namespaces that had to be reloaded. Note that namespace reloading for midje differs from kaocha in that changing a namespace would trigger reloading all depending namespaces. In effect, the midje test runner was sort of a middle ground between kaocha's current watch that re-runs everything and the behavior proposed in this PR that has a form level, instead of ns level, deps analysis that allows one to only rerun individual tests that were affected by reload changes.

for example, with `lein midje :autotest` on a random repository, changing a central/widely used namespace triggers a lot of other ns reloads and tests to run:
```
======================================================================
Loading (matcher-combinators.core matcher-combinators.test-helpers matcher-combinators.matchers matcher-combinators.parser matcher-combinators.clj-test matcher-combinators.test matcher-combinators.matchers-test matcher-combinators.test-test matcher-combinators.parser-test matcher-combinators.midje matcher-combinators.midje-test matcher-combinators.standalone matcher-combinators.standalone-test matcher-combinators.core-test matcher-combinators.cljs-test)

>>> Midje summary:
All checks (184) succeeded.

>>> Output from clojure.test tests:

Ran 49 tests containing 136 assertions.
0 failures, 0 errors.
[Completed at 10:12:19]
```
but if you change a ns that doesn't isn't used by any other namespaces, it reloads and reruns fewer test
```
======================================================================
Loading (matcher-combinators.midje matcher-combinators.midje-test)
nil
All checks (117) succeeded.
```

## side note
this PR depends on this unmerged commit to Clerk: https://github.com/nextjournal/clerk/commit/32ef18e12df6cfd2a38c13ccaa9d6fa932fa0fdb
