### PR TITLE
Extend load-config to also work on resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Added
 
+- Extend `kaocha.config/load-config` to also work on resources
+
 ## Fixed
 
 ## Changed

--- a/test/unit/kaocha/config/included-test.edn
+++ b/test/unit/kaocha/config/included-test.edn
@@ -1,0 +1,2 @@
+{:reporter [kaocha.report.progress/report]
+ :plugins [:other.kaocha.plugin/bar]}

--- a/test/unit/kaocha/config/loaded-test-resource.edn
+++ b/test/unit/kaocha/config/loaded-test-resource.edn
@@ -1,0 +1,4 @@
+#kaocha/v1 #meta-merge
+[#include "kaocha/config/included-test.edn"
+ {:fail-fast? true
+  :plugins [:some.kaocha.plugin/qux]}]

--- a/test/unit/kaocha/config/loaded-test.edn
+++ b/test/unit/kaocha/config/loaded-test.edn
@@ -1,0 +1,3 @@
+#kaocha/v1 #meta-merge
+[#include "./included-test.edn"
+ {:plugins [:some.kaocha.plugin/foo]}]


### PR DESCRIPTION
This could be convenient when kaocha needs to be invoked from code where the contents of the classpath are more reliable than dealing with file system paths.