### PR TITLE
WIP: Drop into REPL when tests error out

### DIFF
--- a/src/kaocha/plugin/repl.clj
+++ b/src/kaocha/plugin/repl.clj
@@ -1,0 +1,40 @@
+(ns kaocha.plugin.repl
+  (:require 
+    [clojure.main]
+    [kaocha.plugin :as plugin :refer [defplugin]]
+    [kaocha.result :as result])
+  (:import [java.io OutputStreamWriter]))
+
+
+(def ^:dynamic *testable* nil)
+
+(comment (defn f [] (* 2 2) ))
+
+(defn repl []
+  (clojure.main/repl :init (fn []
+                             (use 'clojure.repl)
+                             (require '[ kaocha.plugin.repl :refer [ *testable*]]))
+                     :prompt #(print "kaocha.plugin/repl=> ")))
+
+
+(defplugin kaocha.plugin/repl
+  (post-test [{:keys [actual] :as testable} _] 
+             (when (result/erred? testable)
+               (with-redefs [*out* (OutputStreamWriter. System/out)
+                             *e actual
+                             *testable* testable]
+                 (println "Dropping into a repl! (via post-test)")
+                 (repl)))
+             testable)
+
+  (wrap-run [run test-plan]
+            (fn [& args]
+              (try
+                (apply run args)
+                (catch Exception e 
+                  (with-redefs [*out* (OutputStreamWriter. System/out)
+                                *e e
+                                ;; *testable* testable 
+                                ]
+                    (println "Dropping into a repl! (via wrap-run)")
+                    (repl)))))))

--- a/src/kaocha/result.clj
+++ b/src/kaocha/result.clj
@@ -43,6 +43,14 @@
                                :leaf (s/keys :opt [::count ::pass ::error ::fail ::pending])))
   :ret ::result-map)
 
+
+
+(defn erred?
+  "Did this testable, or one of its children, end with an error?"
+  [testable]
+  (let [{::keys [error fail]} (testable-totals testable)]
+    (> error 0)))
+
 (defn failed?
   "Did this testable, or one of its children, fail or error?"
   [testable]
@@ -53,6 +61,11 @@
   "Did this testable fail or error, does not recurse."
   [{::keys [error fail] :or {error 0 fail 0}}]
   (or (> error 0) (> fail 0)))
+
+(defn erred-one?
+  "Did this testable, or one of its children, end with an error?"
+  [{::keys [error fail] :or {error 0 fail 0}}]
+  (> error 0))
 
 (defn totals->clojure-test-summary
   "Turn a kaocha-style result map into a clojure.test style summary map."

--- a/test/unit/kaocha/report_test.clj
+++ b/test/unit/kaocha/report_test.clj
@@ -12,6 +12,11 @@
 
 (require 'kaocha.assertions)
 
+(deftest bad-test
+  
+  (testing "fails with exception"
+    (throw (Exception. ":("))))
+
 (deftest dispatch-extra-keys-test
   (testing "it dispatches to custom clojure.test/report extensions"
     (.addMethod r/clojure-test-report


### PR DESCRIPTION
Adds a proof-of-concept error REPL when tests error out.

- [ ] Work around `capture-output` (or make `capture-output` work around plugins)?
- [ ] Try to get it to work with watch load errors?
- [ ] Add configuration for stopping on errors versus failures
- [ ] Add retry?
- [ ] Open an nREPL (or similar) for connecting to an editor.
- [ ] Include local bindings from test.