### PR TITLE
Disable sporadically failing test on Java 1.8.

### DIFF
--- a/test/unit/kaocha/watch_test.clj
+++ b/test/unit/kaocha/watch_test.clj
@@ -154,7 +154,7 @@
     (integration/spit-file  m (str test-dir "/src/.gitignore") "two" )
     (is (=  #{"one" "two"}   (set (w/merge-ignore-files (str test-dir)))))))
 
-(deftest watch-set-dynamic-vars-test
+(deftest ^{:min-java-version "1.11"} watch-set-dynamic-vars-test
   ; sanity test for #133. Should succeed when this file
   ; is checked via ./bin/kaocha with --watch mode
   (is (do (set! *warn-on-reflection* false)

--- a/test/unit/kaocha/watch_test.clj
+++ b/test/unit/kaocha/watch_test.clj
@@ -104,7 +104,7 @@
          (first (w/reload-config {:kaocha/cli-options {:config-file (str tmp-file)}} []))))))
 
 
-(deftest watch-test
+(deftest ^{:min-java-version "1.11"} watch-test
   (let [{:keys [config-file test-dir] :as m} (integration/test-dir-setup {})
         config (-> (config/load-config config-file)
                    (assoc-in [:kaocha/cli-options :config-file] (str config-file))
@@ -154,7 +154,7 @@
     (integration/spit-file  m (str test-dir "/src/.gitignore") "two" )
     (is (=  #{"one" "two"}   (set (w/merge-ignore-files (str test-dir)))))))
 
-(deftest ^{:min-java-version "1.11"} watch-set-dynamic-vars-test
+(deftest watch-set-dynamic-vars-test
   ; sanity test for #133. Should succeed when this file
   ; is checked via ./bin/kaocha with --watch mode
   (is (do (set! *warn-on-reflection* false)

--- a/test/unit/kaocha/watch_test.clj
+++ b/test/unit/kaocha/watch_test.clj
@@ -71,8 +71,7 @@
   (is (not (w/glob? (.toPath (io/file "xxxx.clj")) [(w/convert "xxy*")])))
   (is (w/glob? (.toPath (io/file "xxxx.clj")) [(w/convert "**xxx.clj")]))
   (is (w/glob? (.toPath (io/file "test/xxxx.clj")) [(w/convert "**xxx.clj")]))
-  (is (w/glob? (.toPath (io/file "test/xxxx.clj")) [(w/convert "***xxx.clj")]))
-  )
+  (is (w/glob? (.toPath (io/file "test/xxxx.clj")) [(w/convert "***xxx.clj")])))
 
 (deftest glob-converted-test
   ; Validate that incompatible patterns are converted and match after conversion. 
@@ -114,8 +113,7 @@
         finish? (atom false)
         q       (w/make-queue)
         out-str (promise)
-        test-file-path (str "test/" prefix "/bar_test.clj")
-        ]
+        test-file-path (str "test/" prefix "/bar_test.clj")]
     (integration/spit-file m "tests.edn" (prn-str config))
     (integration/spit-file m test-file-path (str "(ns " prefix ".bar-test (:require [clojure.test :refer :all])) (deftest xxx-test (is (= :xxx :yyy)))"))
 

--- a/tests.edn
+++ b/tests.edn
@@ -3,7 +3,8 @@
            :profiling
            :print-invocations
            :hooks
-           :notifier]
+           :notifier
+           :kaocha.plugin/version-filter]
 
  :tests [{:id         :unit
           :test-paths ["test/shared"


### PR DESCRIPTION
There's a watch test that sometimes fails on our Java 1.8 runners (although it works on my Ubuntu machine). These tests are useful, but difficult to get right, and so I don't think troubleshooting it is worth it. 

At some point, we'll want to drop Java 8, but it's here to stay for a long time yet so I think disabling this one particular test makes the most sense.