### PR TITLE
Fix "no tests" message

### DIFF
--- a/src/kaocha/api.clj
+++ b/src/kaocha/api.clj
@@ -104,13 +104,12 @@
                                      (::testable/load-error %))
                                 (testable/test-seq test-plan))
                   (if (not (zero? (count (filter ::testable/skip (testable/test-seq-with-skipped test-plan)))))
-                    (output/warn (str "No tests were found and some tests were"
-                                      " skipped; check for misspelled settings"
-                                      " or combinations of settings that no tests"
-                                      " satisfy."))
-                    (output/warn (str "No tests were found. This may be an issue in your test configuration."
-                                      " To investigate, check the :test-paths and :ns-patterns keys in tests.edn."))
-                    )
+                    (output/warn (format (str "All %d tests were skipped."
+                                              " Check for misspelled settings in your Kaocha test configuration"
+                                              " or incorrect focus or skip filters.")
+                                         (count (testable/test-seq-with-skipped test-plan))))
+                    (output/warn (str "No tests were found. This may be an issue in your Kaocha test configuration."
+                                      " To investigate, check the :test-paths and :ns-patterns keys in tests.edn.")))
                   (throw+ {:kaocha/early-exit 0 }))
                 
                 (when (find-ns 'matcher-combinators.core)

--- a/src/kaocha/testable.clj
+++ b/src/kaocha/testable.clj
@@ -235,3 +235,16 @@
     ;; the outer map. When running on an actual testable, do include it.
     (:kaocha.testable/id testable)
     (cons testable)))
+
+(defn test-seq-with-skipped 
+  [testable]
+ "Create a seq of all tests, including any skipped tests.
+ 
+ Typically you want to look at `test-seq` instead." 
+  (cond->> (mapcat test-seq (or (:kaocha/tests testable)
+                                               (:kaocha.test-plan/tests testable)
+                                               (:kaocha.result/tests testable)))
+    ;; When calling test-seq on the top level test-plan/result, don't include
+    ;; the outer map. When running on an actual testable, do include it.
+    (:kaocha.testable/id testable)
+    (cons testable)))


### PR DESCRIPTION
Previously, when filtering on a non-existent test, we'd get our existing warning about no tests being found. Unfortunately, this warning only mentions `ns-patterns` or `test-paths` (#289).

This PR fixes this by adding a new warning message for the filtering and softens the wording on the existing message.