### PR TITLE
Add latest versions of JDK and Clojure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   kaocha: lambdaisland/kaocha@0.0.1
-  clojure: lambdaisland/clojure@0.0.4
+  clojure: lambdaisland/clojure@0.0.5
   win: circleci/windows@2.2.0
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,8 @@ workflows:
       - test:
           matrix:
             parameters:
-              os: [clojure/openjdk16, clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
-              clojure_version: ["1.9.0", "1.10.1"]
+              os: [clojure/openjdk17, clojure/openjdk16,  clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
+              clojure_version: ["1.9.0", "1.10.1", "1.11.1"]
 
       # - windows-test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   kaocha: lambdaisland/kaocha@0.0.1
-  clojure: lambdaisland/clojure@0.0.6
+  clojure: lambdaisland/clojure@0.0.7
   win: circleci/windows@2.2.0
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   kaocha: lambdaisland/kaocha@0.0.1
-  clojure: lambdaisland/clojure@0.0.5
+  clojure: lambdaisland/clojure@0.0.6
   win: circleci/windows@2.2.0
 
 jobs:


### PR DESCRIPTION
We're a bit behind on testing Kaocha against the latest versions of Java and Clojure. Probably no huge issues or we would have heard by now, but still worth testing, IMO.
