### PR TITLE
Add Clojure 1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   kaocha: lambdaisland/kaocha@0.0.1
-  clojure: lambdaisland/clojure@0.0.4
+  clojure: lambdaisland/clojure@0.0.5
   win: circleci/windows@2.2.0
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,8 @@ workflows:
       - test:
           matrix:
             parameters:
-              os: [clojure/openjdk16, clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
-              clojure_version: ["1.9.0", "1.10.1"]
+              os: [clojure/openjdk17, clojure/openjdk16,  clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
+              clojure_version: ["1.9.0", "1.10.1", "1.11.1"]
 
       # - windows-test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   kaocha: lambdaisland/kaocha@0.0.1
-  clojure: lambdaisland/clojure@0.0.7
+  clojure: lambdaisland/clojure@0.0.4
   win: circleci/windows@2.2.0
 
 jobs:
@@ -57,7 +57,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              os: [clojure/openjdk17, clojure/openjdk16,  clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
+              os: [clojure/openjdk16,  clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
               clojure_version: ["1.9.0", "1.10.1", "1.11.1"]
 
       # - windows-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   kaocha: lambdaisland/kaocha@0.0.1
-  clojure: lambdaisland/clojure@0.0.6
+  clojure: lambdaisland/clojure@0.0.7
   win: circleci/windows@2.2.0
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   kaocha: lambdaisland/kaocha@0.0.1
-  clojure: lambdaisland/clojure@0.0.5
+  clojure: lambdaisland/clojure@0.0.6
   win: circleci/windows@2.2.0
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ workflows:
           matrix:
             parameters:
               os: [clojure/openjdk16,  clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
-              clojure_version: ["1.9.0", "1.10.1", "1.11.1"]
+              clojure_version: ["1.9.0", "1.10.3", "1.11.1"]
 
       # - windows-test
 


### PR DESCRIPTION
I had some issues with #296, as upgrading the Clojure orb mysteriously makes one of our tests non-deterministic. However, just adding Clojure 1.11 doesn't require changing the orb, so hopefully this will work and we can come back and figure out the issue with #296 later.