### PR TITLE
Add specs for profiling plugin data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add specs for kaocha.plugin/profiling data (#302).
+
 ## Added
 
 ## Fixed

--- a/src/kaocha/plugin/profiling.clj
+++ b/src/kaocha/plugin/profiling.clj
@@ -7,7 +7,7 @@
   (:import java.time.Instant
            java.time.temporal.ChronoUnit))
 
-(s/def ::start #(instance? Instant % ))
+(s/def ::start #(instance? Instant %))
 (s/def ::duration nat-int?)
 (s/def ::profiling? boolean?)
 (s/def ::count nat-int?)

--- a/src/kaocha/plugin/profiling.clj
+++ b/src/kaocha/plugin/profiling.clj
@@ -1,10 +1,16 @@
 (ns kaocha.plugin.profiling
   (:require [clojure.java.io :as io]
+            [clojure.spec.alpha :as s]
             [clojure.string :as str]
             [kaocha.plugin :as plugin :refer [defplugin]]
             [kaocha.testable :as testable])
   (:import java.time.Instant
            java.time.temporal.ChronoUnit))
+
+(s/def ::start #(instance? Instant % ))
+(s/def ::duration nat-int?)
+(s/def ::profiling? boolean?)
+(s/def ::count nat-int?)
 
 (defn start [testable]
   (assoc testable ::start (Instant/now)))


### PR DESCRIPTION
Plugin authors (like myself) might want to consume profiling data as
part of their plugin. Having these specs available is useful for those
authors so they can write their own specs against this data without
having to violate boundaries and define the specs themselves.

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
