### PR TITLE
Draft: Add summary reporter

### DIFF
--- a/src/kaocha/report.clj
+++ b/src/kaocha/report.clj
@@ -99,7 +99,6 @@
             [kaocha.plugin.capture-output :as capture]
             [kaocha.stacktrace :as stacktrace]
             [kaocha.testable :as testable]
-            [kaocha.testable :as testable]
             [kaocha.util :as util]
             [slingshot.slingshot :refer [throw+]]))
 
@@ -427,6 +426,10 @@
 (def documentation
   "Reporter that prints an overview of all tests bein run using indentation."
   [doc result])
+
+(def summary
+  "Reporter that only prints the results"
+  [result])
 
 (defn tap
   "Reporter for the TAP protocol (Test Anything Protocol)."


### PR DESCRIPTION
Hey friends,

I'm interested in a reporter that does not print anything except for the summary at the end. I would ideally also like a leading "Starting test run" so I know it's working, but there doesn't seem to be support for that at the moment, so I don't mind excluding that.

This is pretty simple and I don't want to put a ton of work into it if there's no interest so here's the minimum working example. If there is tho, I'll write up all of the docs and changelog necessary. I couldn't find where the reporter symbols (the vectors) are tested, which is why I didn't write any tests for this PR.

Thanks so much!