### PR TITLE
switch to deep-diff2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## Fixed
 
+- Fix issue where diffing `(is (= ...))` assertions sometimes fails
+  when comparing records.
+
 ## Changed
 
 - Some error codes were duplicated. This is a **breaking change** if you rely on error codes. 
@@ -19,6 +22,7 @@
 	resolving a reporter var fails, the error code is still 254. You can
 	test for error codes between 240 and 249 to check for plugin errors
 	regardless of cause.
+- Upgraded `lambdaisland/deep-diff` to `lambdaisland/deep-diff2`
 
 # 1.69.1069 (2022-07-26 / 07574ec)
 

--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,7 @@
   org.clojure/spec.alpha       {:mvn/version "0.3.218"}
   org.clojure/tools.cli        {:mvn/version "1.0.206"}
   lambdaisland/tools.namespace {:mvn/version "0.1.247"}
-  lambdaisland/deep-diff       {:mvn/version "0.0-47"}
+  lambdaisland/deep-diff2      {:mvn/version "2.4.138"}
   org.tcrawley/dynapath        {:mvn/version "1.1.0"}
   slingshot/slingshot          {:mvn/version "0.12.2"}
   hawk/hawk                    {:mvn/version "0.2.11"}

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
     </dependency>
     <dependency>
       <groupId>lambdaisland</groupId>
-      <artifactId>deep-diff</artifactId>
-      <version>0.0-47</version>
+      <artifactId>deep-diff2</artifactId>
+      <version>2.4.138</version>
     </dependency>
     <dependency>
       <groupId>slingshot</groupId>

--- a/src/kaocha/assertions.clj
+++ b/src/kaocha/assertions.clj
@@ -2,7 +2,7 @@
   (:require [kaocha.output :as output]
             [clojure.test :as t]
             [kaocha.report :as report]
-            [puget.color :as color]
+            [lambdaisland.deep-diff2.puget.color :as color]
             [clojure.string :as str]
             [slingshot.slingshot :refer [try+ throw+]]))
 

--- a/src/kaocha/matcher_combinators.clj
+++ b/src/kaocha/matcher_combinators.clj
@@ -3,11 +3,11 @@
             [kaocha.output :as output]
             [kaocha.hierarchy :as hierarchy]
             [clojure.test :as t]
-            [lambdaisland.deep-diff :as ddiff]
-            [lambdaisland.deep-diff.printer :as printer]
-            [puget.printer :as puget]
+            [lambdaisland.deep-diff2 :as ddiff]
+            [lambdaisland.deep-diff2.printer-impl :as printer]
+            [lambdaisland.deep-diff2.puget.printer :as puget]
             [fipp.engine :as fipp]
-            [puget.color :as color]))
+            [lambdaisland.deep-diff2.puget.color :as color]))
 
 (def print-handlers {'matcher_combinators.model.Mismatch
                      (fn [printer expr]

--- a/src/kaocha/output.clj
+++ b/src/kaocha/output.clj
@@ -37,7 +37,7 @@
   (throw+ object cause? (apply str args)))
 
 (defn printer [& [opts]]
-  ((jit lambdaisland.deep-diff/printer) (merge {:print-color *colored-output*} opts)))
+  ((jit lambdaisland.deep-diff2/printer) (merge {:print-color *colored-output*} opts)))
 
 (defn print-doc
   ([doc]
@@ -49,4 +49,4 @@
   ([doc]
    (format-doc doc (printer)))
   ([doc printer]
-   ((jit puget.printer/format-doc) printer doc)))
+   ((jit lambdaisland.deep-diff2.puget.printer/format-doc) printer doc)))

--- a/src/kaocha/report.clj
+++ b/src/kaocha/report.clj
@@ -258,7 +258,7 @@
                 (for [actual actuals]
                   (output/format-doc (if (= :none (:kaocha/diff-style kaocha.testable/*config*))
                                        actual
-                                       ((jit lambdaisland.deep-diff/diff) expected actual))
+                                       ((jit lambdaisland.deep-diff2/diff) expected actual))
                                      printer)))]))
       (output/print-doc
        [:span

--- a/test/unit/kaocha/output_test.clj
+++ b/test/unit/kaocha/output_test.clj
@@ -77,7 +77,7 @@
 
   (testing "respects *print-length*"
     (is (= {:err "",
-            :out "[1;31m[[0m[1;33m:aaa[0m\n[1;33m :bbb[0m\n[1;33m :ccc[0m[1;31m][0m\n",
+            :out "[1;31m[[0m[1;33m:aaa[0m\n [1;33m:bbb[0m\n [1;33m:ccc[0m[1;31m][0m\n",
             :result nil}
            (util/with-out-err
              (binding [*print-length* 1]

--- a/test/unit/kaocha/report_test.clj
+++ b/test/unit/kaocha/report_test.clj
@@ -1,11 +1,10 @@
 (ns kaocha.report-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :as t :refer :all]
             [kaocha.report :as r]
             [kaocha.type :as type]
             [kaocha.test-util :refer [with-test-out-str]]
             [kaocha.output :as output]
             [kaocha.hierarchy :as hierarchy]
-            [clojure.test :as t]
             [kaocha.history :as history]
             [kaocha.testable :as testable]
             [slingshot.slingshot :refer [try+]]))
@@ -153,7 +152,7 @@
            (r/print-expr {:expected 1
                           :actual 2}))))
 
-  (is (= "Expected:\n[36m  1[0m\nActual:\n  [31m-1[0m [32m+2[0m\n"
+  (is (= "Expected:\n  [36m1[0m\nActual:\n  [31m-1[0m [32m+2[0m\n"
          (with-out-str
            (r/print-expr {:expected '(= 1 (+ 1 1))
                           :actual '(not (= 1 2))})))))
@@ -164,7 +163,7 @@
                 "it does the thing\n"
                 "Numbers are not equal\n"
                 "Expected:\n"
-                "[36m  1[0m\n"
+                "  [36m1[0m\n"
                 "Actual:\n"
                 "  [31m-1[0m [32m+2[0m\n")
          (with-out-str
@@ -226,7 +225,7 @@
              (r/result {:type :summary :test 5 :pass 5 :fail 0 :error 0 :pending 0}))))))
 
 (deftest result-failures-test
-  (is (= "\n[31mFAIL[m in foo/bar-test (foo.clj:42)\nit does the thing\nNumbers are not equal\nExpected:\n[36m  1[0m\nActual:\n  [31m-1[0m [32m+2[0m\n[31m5 tests, 6 assertions, 1 failures.[m\n"
+  (is (= "\n[31mFAIL[m in foo/bar-test (foo.clj:42)\nit does the thing\nNumbers are not equal\nExpected:\n  [36m1[0m\nActual:\n  [31m-1[0m [32m+2[0m\n[31m5 tests, 6 assertions, 1 failures.[m\n"
          (with-test-out-str
            (binding [
                      history/*history* (atom [{:type :fail


### PR DESCRIPTION
Upgrade from deep-diff1 to deep-diff2 since deep-diff1 is no longer
actively maintained. Resolves #306, #307.

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
