### PR TITLE
Improve warning when notification can't appear.

### DIFF
--- a/doc/plugins/notifier_plugin.md
+++ b/doc/plugins/notifier_plugin.md
@@ -9,10 +9,10 @@ useful in combination with `--watch`, e.g. `bin/kaocha --plugin notifier
 --watch`.
 
 It does this by invoking a shell command which can be configured, so it can be
-used to invoke an arbitrary command or script. By default it will try to
+used to invoke an arbitrary command or script. By default, it will try to
 detect which command to use, using either `notify-send` (Linux) or
 `terminal-notifier` (Mac OS X), either of which may need to be installed
-first.
+first. If those commands aren't available, it uses Java's included notifier. 
 
 Several replacement patterns are available:
 
@@ -28,8 +28,19 @@ Several replacement patterns are available:
 - `%{urgency}` : `normal` if the tests pass, `critical` otherwise, meant for use with `notify-send`
 
 If no command is configured, and neither notification command is found, then
-the plugin will silently do nothing. You can explicitly inhibit its behaviour
+the plugin will print a warning. You can explicitly inhibit its behaviour
 with `--no-notifications`.
+
+You can combine the feature with the profiles feature:
+
+
+``` clojure
+{:plugins #profile {:default [:kaocha.plugin/notifier]
+:ci []}}
+```
+
+This will silence the "Notification not shown because system does not support
+it." warning.
 
 ## Enabling Desktop Notifications
 

--- a/src/kaocha/plugin/notifier.clj
+++ b/src/kaocha/plugin/notifier.clj
@@ -96,9 +96,16 @@
           urgency (if (result/failed? result) TrayIcon$MessageType/ERROR TrayIcon$MessageType/INFO) ]
       (.displayMessage icon (title result) (message result) urgency))
     (catch java.awt.HeadlessException e
-      (output/warn (str "Notification not shown because system is headless. AWT error: " e)) )
+      (output/warn (str "Notification not shown because system is headless. AWT error: " e 
+                        "\nConsider disabling the notifier plugin when using in this context."
+                        "\nIf running on a CI system, you can provide a separate list of plugins for the CI profile."
+                        )) )
     (catch java.lang.UnsupportedOperationException e
-      (output/warn (str "Notification not shown because system does not support it. " e)))))
+      (output/warn (str "Notification not shown because system does not support it. " e
+                        "\nConsider disabling the notifier plugin when using in this context or installing" 
+                        "\neither notify-send (Linux) or terminal-notifier (macOS)."
+                        "\nIf running on a CI system, you can provide a separate list of plugins with notifier removed for the CI profile."
+                        )))))
 
 (defn expand-command
   "Takes a command string including replacement patterns, and a map of

--- a/src/kaocha/plugin/notifier.clj
+++ b/src/kaocha/plugin/notifier.clj
@@ -95,17 +95,13 @@
     (let [icon (tray-icon "kaocha/clojure_logo.png")
           urgency (if (result/failed? result) TrayIcon$MessageType/ERROR TrayIcon$MessageType/INFO) ]
       (.displayMessage icon (title result) (message result) urgency))
-    (catch java.awt.HeadlessException e
-      (output/warn (str "Notification not shown because system is headless. AWT error: " e 
-                        "\nConsider disabling the notifier plugin when using in this context."
-                        "\nIf running on a CI system, you can provide a separate list of plugins for the CI profile."
-                        )) )
-    (catch java.lang.UnsupportedOperationException e
-      (output/warn (str "Notification not shown because system does not support it. " e
+    (catch java.awt.HeadlessException _e
+      (output/warn (str "Notification not shown because system is headless." 
+                        "\nConsider disabling the notifier plugin when using in this context.")))
+    (catch java.lang.UnsupportedOperationException _e
+      (output/warn (str "Notification not shown because system does not support it."
                         "\nConsider disabling the notifier plugin when using in this context or installing" 
-                        "\neither notify-send (Linux) or terminal-notifier (macOS)."
-                        "\nIf running on a CI system, you can provide a separate list of plugins with notifier removed for the CI profile."
-                        )))))
+                        "\neither notify-send (Linux) or terminal-notifier (macOS).")))))
 
 (defn expand-command
   "Takes a command string including replacement patterns, and a map of


### PR DESCRIPTION
Add some helpful context when the system isn't able to display a notification message. From my observations on CircleCI, it appears the HeadlessException doesn't actually fire. Not sure why!

I realized after making and committing this change that an alternative/additional approach would be to disable notifier when the CI environment variable is set. I wasn't able to think of any situations where CI would be set and the user would want to see a notification, but it probably merits more thought. I want to be very careful before applying this kind of "smart" configuration because if it fails, it can be confusing and more frustrating than an extraneous warning.