### PR TITLE
Ensure --watch respects the profile on reload.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Fixed
 
+- Fix configuration parsing when using `--watch`. Previously, profiles would be
+    respected on the initial load, but not after watch reloaded the
+    configuration.
+
 ## Changed
 
 # 1.70.1086 (2022-09-19 / f8d8ad5)

--- a/src/kaocha/watch.clj
+++ b/src/kaocha/watch.clj
@@ -177,8 +177,9 @@
 (defn reload-config [config plugin-chain]
   (if-let [config-file (get-in config [:kaocha/cli-options :config-file])]
     (let [{:kaocha/keys [cli-options cli-args]} config
+          profile (get-in config [:kaocha/cli-options :profile])
           config (-> config-file
-                     (config/load-config)
+                     (config/load-config (if profile {:profile profile} {}))
                      (config/apply-cli-opts cli-options)
                      (config/apply-cli-args cli-args))
           plugin-chain (plugin/load-all (concat (:kaocha/plugins config) (:plugin cli-options)))]


### PR DESCRIPTION
When using profiles with --watch, the initial configuration would be loaded with the desired profile, but subsequent ones would use the :default profile. This is because it would use the initially parsed configuration to run the tests, but then, upon rerunning the test, reload the configuration without taking into account the profile.

Fixes #310 