### PR TITLE
Refactor configuration loading to reduce duplicated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Fixed
 
+- Configuration errors are reported as warnings, rather than causing the entire
+    watcher to crash.
+
 ## Changed
 
 # 1.75.1190 (2023-01-20 / 29f98cc)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Added
 
+- `kaocha.repl/config` accepts a `:profile` key when specifying extra options.
+
 ## Fixed
 
 - Configuration errors are reported as warnings, rather than causing the entire

--- a/src/kaocha/api.clj
+++ b/src/kaocha/api.clj
@@ -99,7 +99,7 @@
           (with-bindings (config/binding-map config)
             (let [config (resolve-reporter config)]
               (let [test-plan (test-plan config)]
-                
+
                 (when-not (some #(or (hierarchy/leaf? %)
                                      (::testable/load-error %))
                                 (testable/test-seq test-plan))
@@ -111,7 +111,7 @@
                     (output/warn (str "No tests were found. This may be an issue in your Kaocha test configuration."
                                       " To investigate, check the :test-paths and :ns-patterns keys in tests.edn.")))
                   (throw+ {:kaocha/early-exit 0 }))
-                
+
                 (when (find-ns 'matcher-combinators.core)
                   (require 'kaocha.matcher-combinators))
 

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -228,8 +228,6 @@
   and displaying messages about any errors."
   ([config-file]
    (load-config2 config-file nil {} nil nil))
-  ([config-file profile]
-   (load-config2 config-file profile {} nil nil))
   ([config-file profile opts]
    (load-config2 config-file profile opts nil nil))
   ([config-file profile opts cli-options cli-args]

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -256,11 +256,6 @@
 (defn plugin-chain-from-config [config cli-options]
   (plugin/load-all (concat (:kaocha/plugins config) (when cli-options (:plugin cli-options)))))
 
-(defn reload-config [config plugin-chain]
-  (if-let [config-file (get-in config [:kaocha/cli-options :config-file])]
-    (let [profile (get-in config [:kaocha/cli-options :profile])]
-      [(load-config2 config-file profile {}) plugin-chain])
-    [config plugin-chain]))
 
 (defn resolve-reporter [reporter]
   (cond

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -224,7 +224,8 @@
     config))
 
 (defn load-config2
-  "Loads config, factoring in profiles, and handling errors."
+  "Loads config from config-file, factoring in profile specified using profile,
+  and displaying messages about any errors."
   ([config-file profile]
    (load-config2 config-file profile {} nil nil))
   ([config-file profile opts]

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -226,6 +226,8 @@
 (defn load-config2
   "Loads config from config-file, factoring in profile specified using profile,
   and displaying messages about any errors."
+  ([config-file]
+   (load-config2 config-file nil {} nil nil))
   ([config-file profile]
    (load-config2 config-file profile {} nil nil))
   ([config-file profile opts]

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -149,7 +149,6 @@
                    #(merge {:resolver aero/resource-resolver} %))
            (read-config-source resource)))))
 
-
 (defn load-config-file
   "Loads and returns configuration from `source` or the file \"tests.edn\"
   if called without arguments.
@@ -247,7 +246,7 @@
                   (catch AssertionError e
                     (output/error "Invalid configuration file:\n"
                                   (.getMessage e))
-                    (throw+ {:kaocha/early-exit 252}))) ]
+                    (throw+ {:kaocha/early-exit 252})))]
      (cond-> config
        check_config_file (update ::warnings conj check_config_file)
        check (update ::warnings conj check)))))
@@ -255,7 +254,6 @@
 ;;Do we really need this?
 (defn plugin-chain-from-config [config cli-options]
   (plugin/load-all (concat (:kaocha/plugins config) (when cli-options (:plugin cli-options)))))
-
 
 (defn resolve-reporter [reporter]
   (cond

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -238,10 +238,11 @@
                     cli-options (apply-cli-opts cli-options)
                     cli-args (apply-cli-args cli-args))
 
-         check_config_file (when (not (. (File. (or config-file "tests.edn")) exists))
+         check_config_file (when (not (. (io/file (or config-file "tests.edn")) exists))
                              (output/warn (format (str "Did not load a configuration file and using the defaults.\n"
                                           "This is fine for experimenting, but for long-term use, we recommend creating a configuration file to avoid changes in behavior between releases.\n"
-                                          "To create a configuration file using the current defaults, create a file named tests.edn that contains '#%s {}'.")
+                                          "To create a configuration file using the current defaults and configuration file location, create a file named %s that contains '#%s {}'.")
+                                                  config-file
                                      current-reader)))
          check  (try
                   (specs/assert-spec :kaocha/config config)

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -259,7 +259,7 @@
 (defn reload-config [config plugin-chain]
   (if-let [config-file (get-in config [:kaocha/cli-options :config-file])]
     (let [profile (get-in config [:kaocha/cli-options :profile])]
-      [(load-config2 config-file profile) plugin-chain])
+      [(load-config2 config-file profile {}) plugin-chain])
     [config plugin-chain]))
 
 (defn resolve-reporter [reporter]

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -220,6 +220,31 @@
                           tests)))))
     config))
 
+(defn apply-cli
+  "Applies command-line options and arguments to the configuration."
+  [config cli-opts cli-args]
+  (some-> config
+      cli-opts (apply-cli-opts cli-opts)
+      cli-args (apply-cli-args cli-args)))
+
+(defn validate-config!
+  "Validates the configuration, printing any warnings and errors and possibly throwing."
+  [config config-file]
+  ;;Check for configuration existence.
+  (when (not (.exists (io/file (or config-file "tests.edn"))))
+    (output/warn (format (str "Did not load a configuration file and using the defaults.\n"
+                              "This is fine for experimenting, but for long-term use, we recommend creating a configuration file to avoid changes in behavior between releases.\n"
+                              "To create a configuration file using the current defaults and configuration file location, create a file named %s that contains '#%s {}'.")
+                         config-file
+                         current-reader))
+    ;;Check configuration conforms to spec
+    (try
+      (specs/assert-spec :kaocha/config config)
+      (catch AssertionError e
+        (output/error "Invalid configuration file:\n"
+                      (.getMessage e))
+        (throw+ {:kaocha/early-exit 252})))))
+
 (defn load-config2
   "Loads config from config-file, factoring in profile specified using profile,
   and displaying messages about any errors."

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -149,9 +149,9 @@
                    #(merge {:resolver aero/resource-resolver} %))
            (read-config-source resource)))))
 
-(defn load-config-file
+(defn load-config
   "Loads and returns configuration from `source` or the file \"tests.edn\"
-  if called without arguments.
+  if called without arguments, without doing further processing.
 
   If the config value loaded from `source` is nil, it returns the default
   configuration, which is the result of `(default-config)`.
@@ -187,16 +187,14 @@
 
   `{:aero/read-config-opts {:resolver resolver-to-use}}`"
   ([]
-   (load-config-file (io/file "tests.edn")))
+   (load-config (io/file "tests.edn")))
   ([source]
-   (load-config-file source {}))
+   (load-config source {}))
   ([source opts]
    (if-some [config (read-config source opts)]
      config
      (read-config nil opts))))
 
-;Alias for backward compatibility
-(def load-config load-config-file)
 
 (defn apply-cli-opts [config options]
   (cond-> config
@@ -231,7 +229,7 @@
    (load-config2 config-file profile opts nil nil))
   ([config-file profile opts cli-options cli-args]
    (let [config (cond-> config-file
-                    true (load-config-file (if profile (assoc opts :profile profile) opts))
+                    true (load-config (if profile (assoc opts :profile profile) opts))
                     cli-options (apply-cli-opts cli-options)
                     cli-args (apply-cli-args cli-args))
 

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -223,11 +223,11 @@
 (defn apply-cli
   "Applies command-line options and arguments to the configuration."
   [config cli-opts cli-args]
-  (some-> config
+  (cond-> config
       cli-opts (apply-cli-opts cli-opts)
       cli-args (apply-cli-args cli-args)))
 
-(defn validate-config!
+(defn validate!
   "Validates the configuration, printing any warnings and errors and possibly throwing."
   [config config-file]
   ;;Check for configuration existence.
@@ -236,14 +236,15 @@
                               "This is fine for experimenting, but for long-term use, we recommend creating a configuration file to avoid changes in behavior between releases.\n"
                               "To create a configuration file using the current defaults and configuration file location, create a file named %s that contains '#%s {}'.")
                          config-file
-                         current-reader))
-    ;;Check configuration conforms to spec
+                         current-reader)))
+  ;Check configuration conforms to spec
     (try
       (specs/assert-spec :kaocha/config config)
+      config
       (catch AssertionError e
         (output/error "Invalid configuration file:\n"
                       (.getMessage e))
-        (throw+ {:kaocha/early-exit 252})))))
+        (throw+ {:kaocha/early-exit 252}))))
 
 (defn load-config2
   "Loads config from config-file, factoring in profile specified using profile,

--- a/src/kaocha/repl.clj
+++ b/src/kaocha/repl.clj
@@ -81,11 +81,7 @@ These will particularly come in handy when developing plugins."}
    (config {}))
   ([extra-config]
    (let [config-file (:config-file extra-config "tests.edn")
-         config      (-> (config/load-config config-file)
-                         (config/merge-config (config/normalize extra-config))
-                         (cond-> #_config
-                           (.exists (io/file config-file))
-                           (assoc-in [:kaocha/cli-options :config-file] config-file)))
+         config      (config/load-config2 config-file)
          plugin-chain (plugin/load-all (:kaocha/plugins config))]
      (plugin/with-plugins plugin-chain
        (plugin/run-hook :kaocha.hooks/config config)))))

--- a/src/kaocha/repl.clj
+++ b/src/kaocha/repl.clj
@@ -81,9 +81,9 @@ These will particularly come in handy when developing plugins."}
    (config {}))
   ([{:keys [profile] :as  extra-config}]
    (let [config-file (:config-file extra-config "tests.edn")
-         config      (-> (config/load-config config-file {:profile profile})
+         config      (-> (config/load-config (config/find-config-and-warn config-file) {:profile profile})
                          (config/merge-config (config/normalize extra-config))
-                         (config/validate! config-file))
+                         (config/validate!))
          plugin-chain (plugin/load-all (:kaocha/plugins config))]
      (plugin/with-plugins plugin-chain
        (plugin/run-hook :kaocha.hooks/config config)))))

--- a/src/kaocha/repl.clj
+++ b/src/kaocha/repl.clj
@@ -81,7 +81,8 @@ These will particularly come in handy when developing plugins."}
    (config {}))
   ([extra-config]
    (let [config-file (:config-file extra-config "tests.edn")
-         config      (config/load-config2 config-file)
+         config      (-> (config/load-config config-file)
+                         (config/validate! config-file))
          plugin-chain (plugin/load-all (:kaocha/plugins config))]
      (plugin/with-plugins plugin-chain
        (plugin/run-hook :kaocha.hooks/config config)))))

--- a/src/kaocha/repl.clj
+++ b/src/kaocha/repl.clj
@@ -82,6 +82,7 @@ These will particularly come in handy when developing plugins."}
   ([extra-config]
    (let [config-file (:config-file extra-config "tests.edn")
          config      (-> (config/load-config config-file)
+                         (config/merge-config (config/normalize extra-config))
                          (config/validate! config-file))
          plugin-chain (plugin/load-all (:kaocha/plugins config))]
      (plugin/with-plugins plugin-chain

--- a/src/kaocha/repl.clj
+++ b/src/kaocha/repl.clj
@@ -79,9 +79,9 @@ These will particularly come in handy when developing plugins."}
   alternative configuration file to use with `:config-file`."
   ([]
    (config {}))
-  ([extra-config]
+  ([{:keys [profile] :as  extra-config}]
    (let [config-file (:config-file extra-config "tests.edn")
-         config      (-> (config/load-config config-file)
+         config      (-> (config/load-config config-file {:profile profile})
                          (config/merge-config (config/normalize extra-config))
                          (config/validate! config-file))
          plugin-chain (plugin/load-all (:kaocha/plugins config))]

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -149,29 +149,10 @@
   (binding [spec/*explain-out* expound/printer]
     (let [{{:keys [config-file plugin profile]} :options} (cli/parse-opts args cli-options)
           config (config/load-config2 config-file (when profile {:profile profile}) {})
-          ;; config                                          (-> config-file
-          ;;                                                     (or "tests.edn")
-          ;;                                                     (config/load-config (if profile
-          ;;                                                                           {:profile profile}
-          ;;                                                                           {})))
-          ;; _check_config_file                              (when (not (. (File. (or config-file "tests.edn")) exists))
-          ;;                                                   (output/warn (format (str "Did not load a configuration file and using the defaults.\n"
-          ;;                                                                             "This is fine for experimenting, but for long-term use, we recommend creating a configuration file to avoid changes in behavior between releases.\n"
-          ;;                                                                             "To create a configuration file using the current defaults, create a file named tests.edn that contains '#%s {}'.")
-          ;;                                                                        config/current-reader)))
-          ;; _check                                         (try
-          ;;                                                  (specs/assert-spec :kaocha/config config)
-          ;;                                                  (catch AssertionError e
-          ;;                                                    (output/error "Invalid configuration file:\n"
-          ;;                                                                  (.getMessage e))
-          ;;                                                    (throw+ {:kaocha/early-exit 252})))
           plugin-chain                                    (plugin/load-all (concat (:kaocha/plugins config) plugin))
           cli-options                                     (plugin/run-hook* plugin-chain :kaocha.hooks/cli-options cli-options)
 
           {:keys [errors options arguments summary]} (cli/parse-opts args cli-options)
-          ;; config                                     (-> config
-          ;;                                                (config/apply-cli-opts options)
-          ;;                                                (config/apply-cli-args (map parse-kw arguments)))
           config (config/load-config2 config-file (when profile profile) {} options (map parse-kw arguments))
           suites                                     (into #{} (map parse-kw) arguments)]
       (plugin/with-plugins plugin-chain

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -148,29 +148,31 @@
 
   (binding [spec/*explain-out* expound/printer]
     (let [{{:keys [config-file plugin profile]} :options} (cli/parse-opts args cli-options)
-          config                                          (-> config-file
-                                                              (or "tests.edn")
-                                                              (config/load-config (if profile
-                                                                                    {:profile profile}
-                                                                                    {})))
-          _check_config_file                              (when (not (. (File. (or config-file "tests.edn")) exists))
-                                                            (output/warn (format (str "Did not load a configuration file and using the defaults.\n"
-                                                                                      "This is fine for experimenting, but for long-term use, we recommend creating a configuration file to avoid changes in behavior between releases.\n"
-                                                                                      "To create a configuration file using the current defaults, create a file named tests.edn that contains '#%s {}'.")
-                                                                                 config/current-reader)))
-          _check                                         (try
-                                                           (specs/assert-spec :kaocha/config config)
-                                                           (catch AssertionError e
-                                                             (output/error "Invalid configuration file:\n"
-                                                                           (.getMessage e))
-                                                             (throw+ {:kaocha/early-exit 252})))
+          config (config/load-config2 config-file (when profile {:profile profile}) {})
+          ;; config                                          (-> config-file
+          ;;                                                     (or "tests.edn")
+          ;;                                                     (config/load-config (if profile
+          ;;                                                                           {:profile profile}
+          ;;                                                                           {})))
+          ;; _check_config_file                              (when (not (. (File. (or config-file "tests.edn")) exists))
+          ;;                                                   (output/warn (format (str "Did not load a configuration file and using the defaults.\n"
+          ;;                                                                             "This is fine for experimenting, but for long-term use, we recommend creating a configuration file to avoid changes in behavior between releases.\n"
+          ;;                                                                             "To create a configuration file using the current defaults, create a file named tests.edn that contains '#%s {}'.")
+          ;;                                                                        config/current-reader)))
+          ;; _check                                         (try
+          ;;                                                  (specs/assert-spec :kaocha/config config)
+          ;;                                                  (catch AssertionError e
+          ;;                                                    (output/error "Invalid configuration file:\n"
+          ;;                                                                  (.getMessage e))
+          ;;                                                    (throw+ {:kaocha/early-exit 252})))
           plugin-chain                                    (plugin/load-all (concat (:kaocha/plugins config) plugin))
           cli-options                                     (plugin/run-hook* plugin-chain :kaocha.hooks/cli-options cli-options)
 
           {:keys [errors options arguments summary]} (cli/parse-opts args cli-options)
-          config                                     (-> config
-                                                         (config/apply-cli-opts options)
-                                                         (config/apply-cli-args (map parse-kw arguments)))
+          ;; config                                     (-> config
+          ;;                                                (config/apply-cli-opts options)
+          ;;                                                (config/apply-cli-args (map parse-kw arguments)))
+          config (config/load-config2 config-file (when profile {:profile profile}) {} options (map parse-kw arguments))
           suites                                     (into #{} (map parse-kw) arguments)]
       (plugin/with-plugins plugin-chain
         (run {:config  config

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -172,7 +172,7 @@
           ;; config                                     (-> config
           ;;                                                (config/apply-cli-opts options)
           ;;                                                (config/apply-cli-args (map parse-kw arguments)))
-          config (config/load-config2 config-file (when profile {:profile profile}) {} options (map parse-kw arguments))
+          config (config/load-config2 config-file (when profile profile) {} options (map parse-kw arguments))
           suites                                     (into #{} (map parse-kw) arguments)]
       (plugin/with-plugins plugin-chain
         (run {:config  config

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -182,7 +182,8 @@
   [m]
   (try+
    (let [config (-> (config/load-config)
-                    (config/merge-config (config/normalize m)))]
+                    (config/merge-config (config/normalize m))
+                    (config/validate!))]
      (if (:kaocha/watch? config)
        (let [[exit-code finish!] ((jit kaocha.watch/run) config)]
          (System/exit @exit-code))

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -157,7 +157,7 @@
 
           {:keys [errors options summary arguments]}                (cli/parse-opts args cli-options)
           ;; Final configuration load once all plugins are loaded:
-          config                                                    (->  (config/load-config config-file (if profile {:profile profile} {}))
+          config                                                    (-> (config/load-config config-file (if profile {:profile profile} {}))
                                                                         (config/apply-cli options (map parse-kw arguments))
                                                                         (config/validate! config-file))
           suites                                                    (into #{} (map parse-kw) arguments)]

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -148,10 +148,11 @@
 
   (binding [spec/*explain-out* expound/printer]
     (let [{{:keys [config-file plugin arguments profile]} :options} (cli/parse-opts args cli-options)
+          config-file                                               (config/find-config-and-warn config-file)
           ;; Initial configuration load to determine plugins.
           config                                                    (->  (config/load-config config-file (if profile {:profile profile} {}))
                                                                         (config/apply-cli {} (map parse-kw arguments))
-                                                                        (config/validate! config-file))
+                                                                        (config/validate!))
           plugin-chain                                              (plugin/load-all (concat (:kaocha/plugins config) plugin))
           cli-options                                               (plugin/run-hook* plugin-chain :kaocha.hooks/cli-options cli-options)
 
@@ -159,7 +160,7 @@
           ;; Final configuration load once all plugins are loaded:
           config                                                    (-> (config/load-config config-file (if profile {:profile profile} {}))
                                                                         (config/apply-cli options (map parse-kw arguments))
-                                                                        (config/validate! config-file))
+                                                                        (config/validate!))
           suites                                                    (into #{} (map parse-kw) arguments)]
       (plugin/with-plugins plugin-chain
         (run {:config  config

--- a/src/kaocha/watch.clj
+++ b/src/kaocha/watch.clj
@@ -178,10 +178,7 @@
   (if-let [config-file (get-in config [:kaocha/cli-options :config-file])]
     (let [{:kaocha/keys [cli-options cli-args]} config
           profile (get-in config [:kaocha/cli-options :profile])
-          config (-> config-file
-                     (config/load-config (if profile {:profile profile} {}))
-                     (config/apply-cli-opts cli-options)
-                     (config/apply-cli-args cli-args))
+          config (config/load-config2 config-file profile {} cli-options cli-args)
           plugin-chain (plugin/load-all (concat (:kaocha/plugins config) (:plugin cli-options)))]
       [config plugin-chain])
     [config plugin-chain]))

--- a/src/kaocha/watch.clj
+++ b/src/kaocha/watch.clj
@@ -119,6 +119,8 @@
                      ;; If a Git pattern contains braces, those should be treated literally
                      ;; Example: src/{ill-advised-filename}.clj => src/\{ill-advised-filename\}.clj
                      ;; (re-find #"[{}]" pattern) (str/replace pattern #"\{(.*)\}" "\\\\{$1\\\\}"  )
+
+
                      (str/replace #"\{(.*)\}" "\\\\{$1\\\\}"))]
     (cond->> cleaned
       ;; If it starts with a single *, it should have **
@@ -130,7 +132,7 @@
       (re-find #"/$" cleaned) (format "%s**")
 
       ;; Otherwise, it should have the same behavior
-      )))
+)))
 
 (s/fdef convert :args (s/cat :pattern string?) :ret string?)
 
@@ -179,10 +181,10 @@
   (if-let [config-file (get-in config [:kaocha/cli-options :config-file])]
     (let [{:kaocha/keys [cli-options cli-args]} config
           profile (get-in config [:kaocha/cli-options :profile])
-          config (try+ 
-                   (config/load-config2 config-file profile {} cli-options cli-args)
-                   (catch :kaocha/early-exit  e
-                     (output/warn "Error loading config: " e "\nFalling back to prior config.")))
+          config (try+
+                  (config/load-config2 config-file profile {} cli-options cli-args)
+                  (catch :kaocha/early-exit  e
+                    (output/warn "Error loading config: " e "\nFalling back to prior config.")))
           plugin-chain (plugin/load-all (concat (:kaocha/plugins config) (:plugin cli-options)))]
       [config plugin-chain])
     [config plugin-chain]))

--- a/src/kaocha/watch.clj
+++ b/src/kaocha/watch.clj
@@ -182,8 +182,10 @@
     (let [{:kaocha/keys [cli-options cli-args]} config
           profile (get-in config [:kaocha/cli-options :profile])
           config (try+
-                  (config/load-config2 config-file profile {} cli-options cli-args)
-                  (catch :kaocha/early-exit  e
+                  (-> (config/load-config config-file {:profile profile})
+                      (config/apply-cli cli-options cli-args)
+                      (config/validate! config-file))
+                  (catch :kaocha/early-exit e
                     (output/warn "Error loading config: " e "\nFalling back to prior config.")))
           plugin-chain (plugin/load-all (concat (:kaocha/plugins config) (:plugin cli-options)))]
       [config plugin-chain])

--- a/src/kaocha/watch.clj
+++ b/src/kaocha/watch.clj
@@ -119,8 +119,6 @@
                      ;; If a Git pattern contains braces, those should be treated literally
                      ;; Example: src/{ill-advised-filename}.clj => src/\{ill-advised-filename\}.clj
                      ;; (re-find #"[{}]" pattern) (str/replace pattern #"\{(.*)\}" "\\\\{$1\\\\}"  )
-
-
                      (str/replace #"\{(.*)\}" "\\\\{$1\\\\}"))]
     (cond->> cleaned
       ;; If it starts with a single *, it should have **

--- a/src/kaocha/watch.clj
+++ b/src/kaocha/watch.clj
@@ -180,9 +180,9 @@
     (let [{:kaocha/keys [cli-options cli-args]} config
           profile (get-in config [:kaocha/cli-options :profile])
           config (try+
-                  (-> (config/load-config config-file {:profile profile})
+                  (-> (config/load-config (config/find-config-and-warn config-file) {:profile profile})
                       (config/apply-cli cli-options cli-args)
-                      (config/validate! config-file))
+                      (config/validate!))
                   (catch :kaocha/early-exit e
                     (output/warn "Error loading config: " e "\nFalling back to prior config.")))
           plugin-chain (plugin/load-all (concat (:kaocha/plugins config) (:plugin cli-options)))]

--- a/test/features/config/warnings.feature
+++ b/test/features/config/warnings.feature
@@ -1,0 +1,39 @@
+
+Feature: Configuration: Warnings
+
+  Kaocha will warn about common mistakes.
+
+
+  Scenario: No config
+    Given a file named "test/my/foo_test.clj" with:
+    """ clojure
+    (ns my.foo-test
+      (:require [clojure.test :refer :all]))
+
+    (deftest var-test
+      (is (= 456 456)))
+    """
+    When I run `bin/kaocha -c alt-tests.edn`
+    Then stderr should contain:
+    """
+    Did not load a configuration file and using the defaults.
+    """
+  Scenario: Warn about bad configuration
+    Given a file named "tests.edn" with:
+    """ clojure
+    #kaocha/v1
+    {:plugins notifier}
+    """
+    And a file named "test/my/foo_test.clj" with:
+    """ clojure
+    (ns my.foo-test
+      (:require [clojure.test :refer :all]))
+
+    (deftest var-test
+      (is (= 456 456)))
+    """
+    When I run `bin/kaocha`
+    Then stderr should contain:
+    """
+    Invalid configuration file:
+    """

--- a/test/unit/kaocha/config/loaded-test-profile.edn
+++ b/test/unit/kaocha/config/loaded-test-profile.edn
@@ -1,0 +1,5 @@
+
+#kaocha/v1 
+{:reporter #profile {:test kaocha.report.progress/report 
+                     :ci kaocha.report/documentation
+                     :default kaocha.report/documentation}}

--- a/test/unit/kaocha/config/loaded-test-spec-mismatch.edn
+++ b/test/unit/kaocha/config/loaded-test-spec-mismatch.edn
@@ -1,0 +1,4 @@
+
+#kaocha/v1 #meta-merge
+[#include "./included-test.edn"
+ {:plugins :some.kaocha.plugin/foo}]

--- a/test/unit/kaocha/config_test.clj
+++ b/test/unit/kaocha/config_test.clj
@@ -175,20 +175,7 @@
                     (with-test-out-str (try (c/load-config2 "test/unit/kaocha/config/loaded-test-spec-mismatch.edn")
                                          (catch Exception _e)))))))
 
-(deftest reload-test
-  (testing "reloading a configuration file produces valid config"
-    (let [orig-config (c/load-config2 "test/unit/kaocha/config/loaded-test.edn")
-          [reloaded-config _] (c/reload-config orig-config nil)] 
-      (is (s/valid? :kaocha/config reloaded-config)
-          (s/explain :kaocha/config reloaded-config))))
-  (testing "reloading a configuration file produces the same config"
-    (let [orig-config (c/load-config2 "test/unit/kaocha/config/loaded-test.edn")
-          [reloaded-config _] (c/reload-config orig-config nil)] 
-      (is (= orig-config reloaded-config))))
-  (testing "reloading a configuration file produces the same config when using a profile"
-    (let [orig-config (c/load-config2 "test/unit/kaocha/config/loaded-test-profile.edn" :test {})
-          [reloaded-config _] (c/reload-config orig-config nil)] 
-      (is (= orig-config reloaded-config)))))
+
 
 
 (deftest apply-cli-opts-test

--- a/test/unit/kaocha/config_test.clj
+++ b/test/unit/kaocha/config_test.clj
@@ -59,7 +59,6 @@
           (c/merge-config {:kaocha/tests [{:id :unit}]}
                           {:kaocha/tests ^:prepend [{:id :integration}]}))))
   (testing "does not override metadata for replace-by-default key test-paths"
-    (print (meta (:kaocha/test-paths {:kaocha/test-paths ^:append ["integration-tests"]})))
     (is (= {:kaocha/test-paths ["unit-tests" "integration-tests" ]}
           (c/merge-config {:kaocha/test-paths ["unit-tests"]}
                           {:kaocha/test-paths ^:append ["integration-tests"]})))))
@@ -139,6 +138,29 @@
     (testing "falls back to default when resource does not exist"
       (is (= expected-default-config
              (c/load-config (io/resource "resource-that-does-not-exist.edn")))))))
+
+(deftest load-config2-test
+  (testing "from file path"
+
+    (testing "supports Aero manipulation"
+      (is (match? {:kaocha/reporter ['kaocha.report.progress/report]
+                   :kaocha/plugins  (m/embeds [:some.kaocha.plugin/foo :other.kaocha.plugin/bar])}
+                  (c/load-config2 "test/unit/kaocha/config/loaded-test.edn"))))
+
+    (testing "falls back to default when file does not exist"
+      (is (= expected-default-config
+             (c/load-config2 "file-that-does-not-exist.edn")))))
+
+  (testing "from resource"
+    (testing "supports Aero manipulation"
+      (is (match? {:kaocha/reporter ['kaocha.report.progress/report]
+                   :kaocha/fail-fast? true
+                   :kaocha/plugins (m/embeds [:some.kaocha.plugin/qux :other.kaocha.plugin/bar])}
+                  (c/load-config2 (io/resource "kaocha/config/loaded-test-resource.edn")))))
+
+    (testing "falls back to default when resource does not exist"
+      (is (= expected-default-config
+             (c/load-config2 (io/resource "resource-that-does-not-exist.edn")))))))
 
 (deftest apply-cli-opts-test
   (is (= {:kaocha/fail-fast? true,

--- a/test/unit/kaocha/config_test.clj
+++ b/test/unit/kaocha/config_test.clj
@@ -57,12 +57,12 @@
                            {:kaocha/reporter '[yyy]}))))
   (testing "does not override metadata for replace-by-default key tests"
     (is (= {:kaocha/tests [{:id :integration} {:id :unit}]}
-          (c/merge-config {:kaocha/tests [{:id :unit}]}
-                          {:kaocha/tests ^:prepend [{:id :integration}]}))))
+           (c/merge-config {:kaocha/tests [{:id :unit}]}
+                           {:kaocha/tests ^:prepend [{:id :integration}]}))))
   (testing "does not override metadata for replace-by-default key test-paths"
-    (is (= {:kaocha/test-paths ["unit-tests" "integration-tests" ]}
-          (c/merge-config {:kaocha/test-paths ["unit-tests"]}
-                          {:kaocha/test-paths ^:append ["integration-tests"]})))))
+    (is (= {:kaocha/test-paths ["unit-tests" "integration-tests"]}
+           (c/merge-config {:kaocha/test-paths ["unit-tests"]}
+                           {:kaocha/test-paths ^:append ["integration-tests"]})))))
 
 (deftest merge-ns-patterns-issue-124-test
   (testing "https://github.com/lambdaisland/kaocha/issues/124"
@@ -163,20 +163,14 @@
              (c/load-config2 (io/resource "resource-that-does-not-exist.edn"))))))
   (testing "loading a file with profiles"
     (testing "specifying a profile"
-      (is (match? {:kaocha/reporter 'kaocha.report.progress/report }
+      (is (match? {:kaocha/reporter 'kaocha.report.progress/report}
                   (c/load-config2 "test/unit/kaocha/config/loaded-test-profile.edn" :test {}))))
     (testing "not specifying a profile"
-      (is (match? { :kaocha/reporter 'kaocha.report/documentation }
+      (is (match? {:kaocha/reporter 'kaocha.report/documentation}
                   (c/load-config2 "test/unit/kaocha/config/loaded-test-profile.edn")))))
   (testing "loading a file that doesn't conform to spec"
     (is (thrown-with-msg? Exception #":early-exit 252"
-                          (c/load-config2 "test/unit/kaocha/config/loaded-test-spec-mismatch.edn")))
-    #_(is (re-find #"[Ii]nvalid configuration" 
-                    (with-test-out-str (try (c/load-config2 "test/unit/kaocha/config/loaded-test-spec-mismatch.edn")
-                                         (catch Exception _e)))))))
-
-
-
+                          (c/load-config2 "test/unit/kaocha/config/loaded-test-spec-mismatch.edn")))))
 
 (deftest apply-cli-opts-test
   (is (= {:kaocha/fail-fast? true,

--- a/test/unit/kaocha/config_test.clj
+++ b/test/unit/kaocha/config_test.clj
@@ -154,13 +154,20 @@
   (testing "from resource"
     (testing "supports Aero manipulation"
       (is (match? {:kaocha/reporter ['kaocha.report.progress/report]
-                   :kaocha/fail-fast? true
                    :kaocha/plugins (m/embeds [:some.kaocha.plugin/qux :other.kaocha.plugin/bar])}
                   (c/load-config2 (io/resource "kaocha/config/loaded-test-resource.edn")))))
 
     (testing "falls back to default when resource does not exist"
       (is (= expected-default-config
-             (c/load-config2 (io/resource "resource-that-does-not-exist.edn")))))))
+             (c/load-config2 (io/resource "resource-that-does-not-exist.edn"))))))
+  (testing "loading a file with profiles"
+    (testing "specifying a profile"
+      (is (match? {:kaocha/reporter 'kaocha.report.progress/report }
+                  (c/load-config2 "test/unit/kaocha/config/loaded-test-profile.edn" :test))))
+    (testing "not specifying a profile"
+      (is (match? { :kaocha/reporter 'kaocha.report/documentation }
+                  (c/load-config2 "test/unit/kaocha/config/loaded-test-profile.edn"))))))
+
 
 (deftest apply-cli-opts-test
   (is (= {:kaocha/fail-fast? true,

--- a/test/unit/kaocha/config_test.clj
+++ b/test/unit/kaocha/config_test.clj
@@ -1,6 +1,7 @@
 (ns kaocha.config-test
   (:require [clojure.java.io :as io]
             [clojure.test :refer :all]
+            [kaocha.test-util :refer [with-test-out-str]]
             [kaocha.config :as c]
             [matcher-combinators.matchers :as m]
             [slingshot.slingshot :refer [try+]]))
@@ -163,10 +164,16 @@
   (testing "loading a file with profiles"
     (testing "specifying a profile"
       (is (match? {:kaocha/reporter 'kaocha.report.progress/report }
-                  (c/load-config2 "test/unit/kaocha/config/loaded-test-profile.edn" :test))))
+                  (c/load-config2 "test/unit/kaocha/config/loaded-test-profile.edn" :test {}))))
     (testing "not specifying a profile"
       (is (match? { :kaocha/reporter 'kaocha.report/documentation }
-                  (c/load-config2 "test/unit/kaocha/config/loaded-test-profile.edn"))))))
+                  (c/load-config2 "test/unit/kaocha/config/loaded-test-profile.edn")))))
+  (testing "loading a file that doesn't conform to spec"
+    (is (thrown-with-msg? Exception #":early-exit 252"
+                          (c/load-config2 "test/unit/kaocha/config/loaded-test-spec-mismatch.edn")))
+    #_(is (re-find #"[Ii]nvalid configuration" 
+                    (with-test-out-str (try (c/load-config2 "test/unit/kaocha/config/loaded-test-spec-mismatch.edn")
+                                         (catch Exception _e)))))))
 
 
 (deftest apply-cli-opts-test

--- a/test/unit/kaocha/config_test.clj
+++ b/test/unit/kaocha/config_test.clj
@@ -1,8 +1,8 @@
 (ns kaocha.config-test
   (:require [clojure.java.io :as io]
             [clojure.test :refer :all]
-            [kaocha.test-util :refer [with-test-out-str]]
             [kaocha.config :as c]
+            [clojure.spec.alpha :as s]
             [matcher-combinators.matchers :as m]
             [slingshot.slingshot :refer [try+]]))
 
@@ -174,6 +174,21 @@
     #_(is (re-find #"[Ii]nvalid configuration" 
                     (with-test-out-str (try (c/load-config2 "test/unit/kaocha/config/loaded-test-spec-mismatch.edn")
                                          (catch Exception _e)))))))
+
+(deftest reload-test
+  (testing "reloading a configuration file produces valid config"
+    (let [orig-config (c/load-config2 "test/unit/kaocha/config/loaded-test.edn")
+          [reloaded-config _] (c/reload-config orig-config nil)] 
+      (is (s/valid? :kaocha/config reloaded-config)
+          (s/explain :kaocha/config reloaded-config))))
+  (testing "reloading a configuration file produces the same config"
+    (let [orig-config (c/load-config2 "test/unit/kaocha/config/loaded-test.edn")
+          [reloaded-config _] (c/reload-config orig-config nil)] 
+      (is (= orig-config reloaded-config))))
+  (testing "reloading a configuration file produces the same config when using a profile"
+    (let [orig-config (c/load-config2 "test/unit/kaocha/config/loaded-test-profile.edn" :test {})
+          [reloaded-config _] (c/reload-config orig-config nil)] 
+      (is (= orig-config reloaded-config)))))
 
 
 (deftest apply-cli-opts-test

--- a/test/unit/kaocha/config_test.clj
+++ b/test/unit/kaocha/config_test.clj
@@ -140,37 +140,37 @@
       (is (= expected-default-config
              (c/load-config (io/resource "resource-that-does-not-exist.edn")))))))
 
-(deftest load-config2-test
+(deftest load-config-for-cli-and-validate-test
   (testing "from file path"
 
     (testing "supports Aero manipulation"
       (is (match? {:kaocha/reporter ['kaocha.report.progress/report]
                    :kaocha/plugins  (m/embeds [:some.kaocha.plugin/foo :other.kaocha.plugin/bar])}
-                  (c/load-config2 "test/unit/kaocha/config/loaded-test.edn"))))
+                  (c/load-config-for-cli-and-validate "test/unit/kaocha/config/loaded-test.edn" {}))))
 
     (testing "falls back to default when file does not exist"
       (is (= expected-default-config
-             (c/load-config2 "file-that-does-not-exist.edn")))))
+             (c/load-config-for-cli-and-validate "file-that-does-not-exist.edn" {})))))
 
   (testing "from resource"
     (testing "supports Aero manipulation"
       (is (match? {:kaocha/reporter ['kaocha.report.progress/report]
                    :kaocha/plugins (m/embeds [:some.kaocha.plugin/qux :other.kaocha.plugin/bar])}
-                  (c/load-config2 (io/resource "kaocha/config/loaded-test-resource.edn")))))
+                  (c/load-config-for-cli-and-validate (io/resource "kaocha/config/loaded-test-resource.edn") {}))))
 
     (testing "falls back to default when resource does not exist"
       (is (= expected-default-config
-             (c/load-config2 (io/resource "resource-that-does-not-exist.edn"))))))
+             (c/load-config-for-cli-and-validate (io/resource "resource-that-does-not-exist.edn") {})))))
   (testing "loading a file with profiles"
     (testing "specifying a profile"
       (is (match? {:kaocha/reporter 'kaocha.report.progress/report}
-                  (c/load-config2 "test/unit/kaocha/config/loaded-test-profile.edn" :test {}))))
+                  (c/load-config-for-cli-and-validate "test/unit/kaocha/config/loaded-test-profile.edn" {:profile :test}))))
     (testing "not specifying a profile"
       (is (match? {:kaocha/reporter 'kaocha.report/documentation}
-                  (c/load-config2 "test/unit/kaocha/config/loaded-test-profile.edn")))))
+                  (c/load-config-for-cli-and-validate "test/unit/kaocha/config/loaded-test-profile.edn" {})))))
   (testing "loading a file that doesn't conform to spec"
     (is (thrown-with-msg? Exception #":early-exit 252"
-                          (c/load-config2 "test/unit/kaocha/config/loaded-test-spec-mismatch.edn")))))
+                          (c/load-config-for-cli-and-validate "test/unit/kaocha/config/loaded-test-spec-mismatch.edn" {})))))
 
 (deftest apply-cli-opts-test
   (is (= {:kaocha/fail-fast? true,

--- a/test/unit/kaocha/config_test.clj
+++ b/test/unit/kaocha/config_test.clj
@@ -157,9 +157,11 @@
       (is (match? {:kaocha/reporter ['kaocha.report.progress/report]
                    :kaocha/plugins (m/embeds [:some.kaocha.plugin/qux :other.kaocha.plugin/bar])}
                   (c/load-config-for-cli-and-validate (io/resource "kaocha/config/loaded-test-resource.edn") {}))))
-
     (testing "falls back to default when resource does not exist"
-      (is (= expected-default-config
+      (is (match? 
+            ;; Deliberately minimal case because we want to test this behavior
+            ;; (fallback to tests.edn) without tying too much to tests.edn
+            {:kaocha.hooks/pre-load ['kaocha.assertions/load-assertions] }
              (c/load-config-for-cli-and-validate (io/resource "resource-that-does-not-exist.edn") {})))))
   (testing "loading a file with profiles"
     (testing "specifying a profile"

--- a/test/unit/kaocha/repl_test.clj
+++ b/test/unit/kaocha/repl_test.clj
@@ -16,3 +16,33 @@
                           :kaocha.plugin.alpha/xfail]}
 
        (repl/config {:config-file "fixtures/custom_config.edn"}))))
+
+(deftest extra-config-test
+  (is (match?
+        '{:kaocha/tests [{:kaocha.testable/id :foo
+                         :kaocha/test-paths ["test/foo"]}]
+         :kaocha/reporter [kaocha.report.progress/report]
+         :kaocha/color? true
+         :kaocha/fail-fast? true
+         :kaocha/plugins [:kaocha.plugin/randomize
+                          :kaocha.plugin/filter
+                          :kaocha.plugin/capture-output
+                          :kaocha.plugin.alpha/xfail]}
+        (repl/config {:color? true :config-file "fixtures/custom_config.edn"}))))
+
+
+(deftest config-with-profile-test
+  (testing  "specifying a profile"
+    (is (match?
+          '{:kaocha/tests [{:kaocha.testable/id :unit
+                            :kaocha/test-paths ["test"]}]
+            :kaocha/reporter kaocha.report.progress/report }
+          (repl/config {:profile :test :config-file "test/unit/kaocha/config/loaded-test-profile.edn"}))))
+  (testing "not specifying a profile"
+    (is (match?
+          '{:kaocha/tests [{:kaocha.testable/id :unit
+                            :kaocha/test-paths ["test"]}]
+            :kaocha/reporter kaocha.report/documentation }
+          (repl/config {:config-file "test/unit/kaocha/config/loaded-test-profile.edn"})))))
+
+

--- a/test/unit/kaocha/watch_test.clj
+++ b/test/unit/kaocha/watch_test.clj
@@ -67,7 +67,6 @@
   (is (= "README.md" (w/convert "README.md")))
   (is (= "README.md" (w/convert "README.md "))))
 
-
 (deftest glob-converted-unchanged-test
   ; Validate that compatible patterns still match/fail to match after conversion.
   (is (w/glob? (.toPath (io/file "xxxx.clj")) [(w/convert "xxx*")]))
@@ -105,7 +104,6 @@
        (let [tmp-file (File/createTempFile "tests" ".edn")]
          (spit tmp-file "#kaocha/v1 {:tests [{:id :foo}]}")
          (first (w/reload-config {:kaocha/cli-options {:config-file (str tmp-file)}} []))))))
-
 
 (deftest ^{:min-java-version "1.11"} watch-test
   (let [{:keys [config-file test-dir] :as m} (integration/test-dir-setup {})
@@ -194,16 +192,16 @@
 (deftest reload-test
   (testing "reloading a configuration file produces valid config"
     (let [orig-config (c/load-config2 "test/unit/kaocha/config/loaded-test.edn")
-          [reloaded-config _] (w/reload-config orig-config nil)] 
+          [reloaded-config _] (w/reload-config orig-config nil)]
       (is (s/valid? :kaocha/config reloaded-config)
           (s/explain :kaocha/config reloaded-config))))
   (testing "reloading a configuration file produces the same config"
     (let [orig-config (c/load-config2 "test/unit/kaocha/config/loaded-test.edn")
-          [reloaded-config _] (w/reload-config orig-config nil)] 
+          [reloaded-config _] (w/reload-config orig-config nil)]
       (is (= orig-config reloaded-config))))
   (testing "reloading a configuration file produces the same config when using a profile"
     (let [orig-config (c/load-config2 "test/unit/kaocha/config/loaded-test-profile.edn" :test {})
-          [reloaded-config _] (w/reload-config orig-config nil)] 
+          [reloaded-config _] (w/reload-config orig-config nil)]
       (is (= orig-config reloaded-config)))))
      
 ;;TODO move to cucumber

--- a/test/unit/kaocha/watch_test.clj
+++ b/test/unit/kaocha/watch_test.clj
@@ -191,16 +191,16 @@
 
 (deftest reload-test
   (testing "reloading a configuration file produces valid config"
-    (let [orig-config (c/load-config2 "test/unit/kaocha/config/loaded-test.edn")
+    (let [orig-config (c/load-config-for-cli-and-validate "test/unit/kaocha/config/loaded-test.edn" {})
           [reloaded-config _] (w/reload-config orig-config nil)]
       (is (s/valid? :kaocha/config reloaded-config)
           (s/explain :kaocha/config reloaded-config))))
   (testing "reloading a configuration file produces the same config"
-    (let [orig-config (c/load-config2 "test/unit/kaocha/config/loaded-test.edn")
+    (let [orig-config (c/load-config-for-cli-and-validate "test/unit/kaocha/config/loaded-test.edn" {})
           [reloaded-config _] (w/reload-config orig-config nil)]
       (is (= orig-config reloaded-config))))
   (testing "reloading a configuration file produces the same config when using a profile"
-    (let [orig-config (c/load-config2 "test/unit/kaocha/config/loaded-test-profile.edn" :test {})
+    (let [orig-config (c/load-config-for-cli-and-validate "test/unit/kaocha/config/loaded-test-profile.edn" {:profile :test})
           [reloaded-config _] (w/reload-config orig-config nil)]
       (is (= orig-config reloaded-config)))))
      

--- a/test/unit/kaocha/watch_test.clj
+++ b/test/unit/kaocha/watch_test.clj
@@ -1,5 +1,7 @@
 (ns kaocha.watch-test
   (:require [clojure.test :refer :all]
+            [clojure.spec.alpha :as s]
+            [kaocha.config :as c]
             [kaocha.watch :as w]
             [kaocha.platform :as platform]
             [kaocha.test-util :as util]
@@ -189,6 +191,21 @@
            @out-str))
     (is (= 0 @exit-code))))
 
+(deftest reload-test
+  (testing "reloading a configuration file produces valid config"
+    (let [orig-config (c/load-config2 "test/unit/kaocha/config/loaded-test.edn")
+          [reloaded-config _] (w/reload-config orig-config nil)] 
+      (is (s/valid? :kaocha/config reloaded-config)
+          (s/explain :kaocha/config reloaded-config))))
+  (testing "reloading a configuration file produces the same config"
+    (let [orig-config (c/load-config2 "test/unit/kaocha/config/loaded-test.edn")
+          [reloaded-config _] (w/reload-config orig-config nil)] 
+      (is (= orig-config reloaded-config))))
+  (testing "reloading a configuration file produces the same config when using a profile"
+    (let [orig-config (c/load-config2 "test/unit/kaocha/config/loaded-test-profile.edn" :test {})
+          [reloaded-config _] (w/reload-config orig-config nil)] 
+      (is (= orig-config reloaded-config)))))
+     
 ;;TODO move to cucumber
 (deftest ^{:min-java-version "1.11"} watch-load-error-test
   (let [{:keys [config-file test-dir] :as m} (integration/test-dir-setup {})


### PR DESCRIPTION
There's duplicated config logic across `kaocha.runner` and `kaocha.watch`.

In addition to simplifying maintenance, this change would:
* Avoid future issues where configuration loading diverges in `kaocha.runner` and `kaocha.watch`, like #310.
* Provide an easy way to work with configuration at the REPL.
* Allow watch to display errors when an invalid configuration is reloaded.

Relatedly, we may be able to address this TODO:

```
   ;; TODO: we're calling the config hook here in multiple places, and it's also
  ;; being called in `kaocha.api`. Given that we already need the fully expanded
  ;; config here (since now we're potentially adding suites in the config hook),
  ;; we should call it once at the top here, and pass the processed config into
  ;; kaocha.api. Punting on that because it requires a coordinated update in
  ;; kaocha.repl and kaocha-boot.
```

I suspect when `kaocha.watch` was first created it was easy enough to keep these two places in sync and most of the complexity has been added since.