### PR TITLE
Add timeout to notify-send command, plus commandline option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## Added
 
+- Configure a timeout for notifications with --notification-timeout or :kaocha.plugin.notifier/timeout.
+
 ## Fixed
 
 - Fix configuration parsing when using `--watch`. Previously, profiles would be
-    respected on the initial load, but not after watch reloaded the
-    configuration.
+  respected on the initial load, but not after watch reloaded the configuration.
+- Notifier now reports errors in your notification command instead of silently
+  failing.
 
 ## Changed
 
@@ -25,15 +28,15 @@
 ## Changed
 
 - Some error codes were duplicated. This is a **breaking change** if you rely on error codes. 
-    - When a test suite configuration value is not a collection or symbol, the
-	error code is now 250 instead of 252. The error code 252 is still used
-	when the configuration file fails to load.
-    - When registering a plugin fails due to being unable to load a namespace,
-	the error code is now 249 instead of 254. When registering a plugin
-	fails for other reasons, the error code is now 248 instead of 254. When
-	resolving a reporter var fails, the error code is still 254. You can
-	test for error codes between 240 and 249 to check for plugin errors
-	regardless of cause.
+  - When a test suite configuration value is not a collection or symbol, the
+    error code is now 250 instead of 252. The error code 252 is still used
+    when the configuration file fails to load.
+  - When registering a plugin fails due to being unable to load a namespace,
+    the error code is now 249 instead of 254. When registering a plugin
+    fails for other reasons, the error code is now 248 instead of 254. When
+    resolving a reporter var fails, the error code is still 254. You can
+    test for error codes between 240 and 249 to check for plugin errors
+    regardless of cause.
 - Upgraded `lambdaisland/deep-diff` to `lambdaisland/deep-diff2`
 
 # 1.69.1069 (2022-07-26 / 07574ec)
@@ -53,8 +56,8 @@
 ## Fixed
 
 - Fix misleading error message when all tests are filtered out. Previously, it
-    would misleadingly suggest you correct the `test-paths` and `ns-patterns`
-    configuration keys.
+  would misleadingly suggest you correct the `test-paths` and `ns-patterns`
+  configuration keys.
 - Fix overflow with the `gc-profiling` plugin when there's too many bytes.
 
 # 1.66.1034 (2022-04-26 / 7a5824a)
@@ -71,7 +74,7 @@
 
 - Fix issue with `gc-profiling` plugin when there's a syntax error.
 - Ensure that modifications that are done by deleting and recreating the file
-    are picked up by using `--watch` with Beholder.
+  are picked up by using `--watch` with Beholder.
 
 ## Changed
 

--- a/doc/plugins/notifier_plugin.md
+++ b/doc/plugins/notifier_plugin.md
@@ -8,16 +8,16 @@ of tests passed/errored/failed at the end of each test run. It's particularly
 useful in combination with `--watch`, e.g. `bin/kaocha --plugin notifier
 --watch`.
 
-It does this by invoking a shell command which can be configured, so it can be
-used to invoke an arbitrary command or script. By default, it will try to
-detect which command to use, using either `notify-send` (Linux) or
-`terminal-notifier` (Mac OS X), either of which may need to be installed
-first. If those commands aren't available, it uses Java's included notifier. 
+It does this by invoking a shell command that can be configured, so it can be
+used to invoke an arbitrary command or script. By default, it will try to detect
+which command to use, using either `notify-send` (Linux) or `terminal-notifier`
+(Mac OS X), either of which may need to be installed first. If those commands
+aren't available, it uses Java's included notifier. 
 
 Several replacement patterns are available:
 
 - `%{title}` : The notification title, either `⛔️ Failing` or `✅ Passing`
-- `%{message}` : Test result summary, e.g. `5 tests, 12 assertions, 0 failures`
+- `%{message}` : Test result summary, e.g., `5 tests, 12 assertions, 0 failures`
 - `%{icon}` : Full local path to an icon to use (currently uses the Clojure icon)
 - `%{failed?}` : `true` if any tests failed or errored, `false` otherwise
 - `%{count}` : the number of tests
@@ -26,6 +26,14 @@ Several replacement patterns are available:
 - `%{error}` : the number of errors
 - `%{pending}` : the number of pending tests
 - `%{urgency}` : `normal` if the tests pass, `critical` otherwise, meant for use with `notify-send`
+- '%{timeout}` : configured timeout in milliseconds before the notification should disappear. By
+    default, it passes -1, which corresponds to the default timeout when using
+    `notify-send`.
+
+Note that notifications don't time out on
+[GNOME](https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/112) and Ubuntu when
+using [Notify
+OSD](https://bugs.launchpad.net/ubuntu/+source/notify-osd/+bug/390508).
 
 If no command is configured, and neither notification command is found, then
 the plugin will print a warning. You can explicitly inhibit its behaviour

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -136,17 +136,19 @@
      ;; :aero/read-config-opts of opts
      (read-config-source file opts))))
 
-(letfn [(only-resolve-resources-by-default [read-config-opts]
-          (merge {:resolver aero/resource-resolver} read-config-opts))]
-  (extend-protocol ConfigSource
-    URL ;; resource
-    (read-config [resource opts]
-      (when resource
-        ;; Note: we only #include resources
-        ;; unless overridden in :aero/read-config-opts of opts
-        (let [opts (update opts :aero/read-config-opts
-                           only-resolve-resources-by-default)]
-          (read-config-source resource opts))))))
+(def- only-resolve-resources-by-default [read-config-opts]
+  (merge {:resolver aero/resource-resolver}
+         read-config-opts))
+
+(extend-protocol ConfigSource
+  URL ;; resource
+  (read-config [resource opts]
+    (when resource
+      ;; Note: we only #include resources
+      ;; unless overridden in :aero/read-config-opts of opts
+      (let [opts (update opts :aero/read-config-opts
+                         only-resolve-resources-by-default)]
+        (read-config-source resource opts)))))
 
 (defn load-config
   "Loads and returns configuration from `source` or the file \"tests.edn\"

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -8,7 +8,7 @@
   (:import (java.io File)
            (java.net URL)))
 
-;the reader literal for the current default:
+;; the reader literal for the current default:
 (def current-reader 'kaocha/v1)
 
 (defn default-config []
@@ -121,7 +121,7 @@
 
   nil ;; handle nil source case
   (read-config [_ _]
-   (default-config))
+    (default-config))
 
   Object ;; keep existing default behaviour
   (read-config [path opts]
@@ -129,16 +129,12 @@
 
   File
   (read-config [^File file opts]
-   (when (.exists file)
-     ;; Note: since the default :resolver in Aero is aero/adaptive-resolver,
-     ;; #include will first check if there is a resource with that name
-     ;; and will only revert to a file if not, unless overridden in
-     ;; :aero/read-config-opts of opts
-     (read-config-source file opts))))
-
-(def- only-resolve-resources-by-default [read-config-opts]
-  (merge {:resolver aero/resource-resolver}
-         read-config-opts))
+    (when (.exists file)
+      ;; Note: since the default :resolver in Aero is aero/adaptive-resolver,
+      ;; #include will first check if there is a resource with that name
+      ;; and will only revert to a file if not, unless overridden in
+      ;; :aero/read-config-opts of opts
+      (read-config-source file opts))))
 
 (extend-protocol ConfigSource
   URL ;; resource
@@ -146,9 +142,10 @@
     (when resource
       ;; Note: we only #include resources
       ;; unless overridden in :aero/read-config-opts of opts
-      (let [opts (update opts :aero/read-config-opts
-                         only-resolve-resources-by-default)]
-        (read-config-source resource opts)))))
+      (->> (update opts
+                   :aero/read-config-opts
+                   #(merge {:resolver aero/resource-resolver} %))
+           (read-config-source resource)))))
 
 (defn load-config
   "Loads and returns configuration from `source` or the file \"tests.edn\"

--- a/src/kaocha/plugin/notifier.clj
+++ b/src/kaocha/plugin/notifier.clj
@@ -126,11 +126,10 @@
         title   (title result)
         icon    (icon-path)
         failed? (result/failed? result)
-        urgency (if failed? "critical" "normal")]
-    (apply sh (expand-command command {:message message
+        urgency (if failed? "critical" "normal")
+        expanded-command (expand-command command {:message message
                                        :title title
                                        :icon icon
-
                                        :urgency urgency
                                        :count count
                                        :pass pass
@@ -138,7 +137,16 @@
                                        :error error
                                        :pending pending
                                        :failed? failed?
-                                       :timeout timeout}))))
+                                       :timeout timeout})
+      {:keys [exit err] :as  command-result} (apply sh expanded-command)
+        ]
+    (when (not (zero? exit))
+      (output/warn (format
+                     "Notification command exited with status code %s\nand message \"%s\"\nand command \"%s\""
+                     exit
+                     err
+                     (apply str (interpose \space expanded-command)))))
+    command-result))
 
 (defplugin kaocha.plugin/notifier
   "Run a shell command after each completed test run, by default will run a

--- a/src/kaocha/plugin/notifier.clj
+++ b/src/kaocha/plugin/notifier.clj
@@ -142,7 +142,11 @@
         ]
     (when (not (zero? exit))
       (output/warn (format
-                     "Notification command exited with status code %s\nand message \"%s\"\nand command \"%s\""
+                     (str 
+                       "Notification command exited with status code: %s"
+                       "Error message (stderr): \"%s\""
+                       "Command: \"%s\""
+                       "Check your configuration for :kaocha.plugin.notifier/notification-timeout and :kaocha.plugin.notifier/command.")
                      exit
                      err
                      (apply str (interpose \space expanded-command)))))

--- a/src/kaocha/plugin/notifier.clj
+++ b/src/kaocha/plugin/notifier.clj
@@ -155,10 +155,11 @@
 
   (config [config]
     (let [cli-options (:kaocha/cli-options config)
-          cli-flag (:notifications cli-options)]
+          cli-flag (:notifications cli-options)
+          timeout (:notification-timeout cli-options (::timeout config -1))]
       (assoc config
              ::command (::command config (detect-command))
-             ::timeout (:notification-timeout cli-options (::timeout config))
+             ::timeout timeout 
              ::notifications?
              (if (some? cli-flag)
                cli-flag
@@ -167,6 +168,6 @@
   (post-run [result]
     (when (::notifications? result)
       (if-let [command (::command result)]
-        (run-command command result (::timeout result -1)) ;; -1 appears to use default behavior. 0 appears to keep it on screen indefinitely.
+        (run-command command result (::timeout result))
         (send-tray-notification result)))
     result))

--- a/src/kaocha/repl.clj
+++ b/src/kaocha/repl.clj
@@ -58,7 +58,7 @@ out what's going on. The [[config]] and [[test-plan]] functions provide this
 kind of debugging information.
 
 These will particularly come in handy when developing plugins."}
- kaocha.repl
+    kaocha.repl
   (:require [kaocha.config :as config]
             [kaocha.plugin :as plugin]
             [kaocha.api :as api]

--- a/test/unit/kaocha/plugin/notifier_test.clj
+++ b/test/unit/kaocha/plugin/notifier_test.clj
@@ -75,10 +75,12 @@
                                                 :kaocha.result/pass 2
                                                 :kaocha.result/fail 1
                                                 :kaocha.result/error 4
-                                                :kaocha.result/pending 5}]}))))
+                                                :kaocha.result/pending 5}]}
+                        -1))))
 
 (deftest notifier-cli-options-hook-test
-  (is (= [[nil "--[no-]notifications" "Enable/disable the notifier plugin, providing desktop notifications. Defaults to true."]]
+  (is (= [[nil "--[no-]notifications" "Enable/disable the notifier plugin, providing desktop notifications. Defaults to true."]
+          [nil "--notification-timeout TIMEOUT" "Set a timeout value for desktop notifications through the notifier plugin."]]
          (n/notifier-cli-options-hook []))))
 
 (deftest notifier-config-hook-test

--- a/test/unit/kaocha/plugin/notifier_test.clj
+++ b/test/unit/kaocha/plugin/notifier_test.clj
@@ -75,8 +75,8 @@
                                                 :kaocha.result/pass 2
                                                 :kaocha.result/fail 1
                                                 :kaocha.result/error 4
-                                                :kaocha.result/pending 5}]}
-                        -1))))
+                                                :kaocha.result/pending 5}]
+                         :kaocha.plugin.notifier/timeout -1}))))
 
 (deftest notifier-cli-options-hook-test
   (is (= [[nil "--[no-]notifications" "Enable/disable the notifier plugin, providing desktop notifications. Defaults to true."]
@@ -100,7 +100,7 @@
               (n/notifier-config-hook {:kaocha/cli-options {:notifications false}}))))
 
 (deftest notifier-post-run-hook-test
-  (let [gen-file-name #(str (System/getProperty "java.io.tmpdir") (System/getProperty "file.separator") 
+  (let [gen-file-name #(str (System/getProperty "java.io.tmpdir") (System/getProperty "file.separator")
                             (gensym (str (namespace `_) "-" (rand-int 10000))))
         f1 (gen-file-name)
         f2 (gen-file-name)


### PR DESCRIPTION
The timeout doesn't work in all situations, including with terminal-notifier on macOS, with Java's built-in TrayIcon, or with notify-send on certain platforms. 

Partially fixes #311 and fixes #102.