### PR TITLE
Add Java 17 and 19 to test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  kaocha: lambdaisland/kaocha@0.0.1
-  clojure: lambdaisland/clojure@0.0.4
+  kaocha: lambdaisland/kaocha@0.0.3
+  clojure: lambdaisland/clojure@0.0.8
   win: circleci/windows@2.2.0
 
 jobs:
@@ -57,7 +57,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              os: [clojure/openjdk16,  clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
+              os: [clojure/openjdk19, clojure/openjdk17, clojure/openjdk16,  clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
               clojure_version: ["1.9.0", "1.10.3", "1.11.1"]
 
       # - windows-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  kaocha: lambdaisland/kaocha@0.0.3
+  kaocha: lambdaisland/kaocha@0.0.1
   clojure: lambdaisland/clojure@0.0.8
   win: circleci/windows@2.2.0
 
@@ -57,7 +57,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              os: [clojure/openjdk19, clojure/openjdk17, clojure/openjdk16,  clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
+              os: [clojure/openjdk16,  clojure/openjdk15, clojure/openjdk11, clojure/openjdk8]
               clojure_version: ["1.9.0", "1.10.3", "1.11.1"]
 
       # - windows-test

--- a/test/features/command_line/print_config.feature
+++ b/test/features/command_line/print_config.feature
@@ -11,20 +11,20 @@ Feature: CLI: Print the Kaocha configuration
 
   Scenario: Using `--print-config`
     When I run `bin/kaocha --print-config`
-    Then the output should contain:
+    Then the EDN output should contain:
       """ clojure
       {:kaocha.plugin.randomize/randomize? false,
        :kaocha/reporter [kaocha.report/dots],
        :kaocha/color? false,
-       :kaocha/fail-fast? false,
+       :kaocha/fail-fast? false}
       """
-    And the output should contain:
+    And the EDN output should contain:
       """ clojure
-       :kaocha/tests
+       {:kaocha/tests
        [{:kaocha.testable/type :kaocha.type/clojure.test,
          :kaocha.testable/id :unit,
          :kaocha/ns-patterns ["-test$"],
          :kaocha/source-paths ["src"],
          :kaocha/test-paths ["test"],
-         :kaocha.filter/skip-meta [:kaocha/skip]}],
+         :kaocha.filter/skip-meta [:kaocha/skip]}]}
       """

--- a/test/step_definitions/kaocha_integration.clj
+++ b/test/step_definitions/kaocha_integration.clj
@@ -1,7 +1,8 @@
 (ns features.steps.kaocha-integration
   ^{:clojure.tools.namespace.repl/load false
     :clojure.tools.namespace.repl/unload false}
-  (:require [clojure.java.io :as io]
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
             [clojure.java.shell :as shell]
             [clojure.string :as str]
             [clojure.test :as t :refer :all]
@@ -63,6 +64,14 @@
 (Then "the output should not contain" [m output]
   (is (not (str/includes? (:out m) output)))
   m)
+
+(Then "the EDN output should contain:" [m output]
+      (let  [actual (edn/read-string (:out m))
+             expected (edn/read-string output)]
+        (is (= (type actual) (type expected)))
+        (is (= (select-keys actual (keys expected)) expected)))
+      m)
+
 
 (Then "stderr should contain" [m output]
   (is (substring? output (:err m)))

--- a/test/step_definitions/kaocha_integration.clj
+++ b/test/step_definitions/kaocha_integration.clj
@@ -68,7 +68,6 @@
 (Then "the EDN output should contain:" [m output]
       (let  [actual (edn/read-string (:out m))
              expected (edn/read-string output)]
-        (is (= (type actual) (type expected)))
         (is (= (select-keys actual (keys expected)) expected)))
       m)
 


### PR DESCRIPTION
Adds the latest LTS (17) and the latest interim release (19).