### PR TITLE
fix unreachable case when :kaocha.spec.test.check/syms is a collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   respected on the initial load, but not after watch reloaded the configuration.
 - Notifier now reports errors in your notification command instead of silently
   failing.
+- Fixed `java.lang.IllegalArgumentException: No matching clause: []` exception
+  when `:kaocha.spec.test.check/syms` is a collection.
 
 ## Changed
 

--- a/src/kaocha/type/spec/test/check.clj
+++ b/src/kaocha/type/spec/test/check.clj
@@ -32,7 +32,8 @@
     (condp = syms
       :all-fdefs   (all-fdef-tests check)
       :other-fdefs nil ;; TODO: this requires orchestration from the plugin
-      :else        (type.fdef/load-testables check syms))))
+      ;; else
+      (type.fdef/load-testables check syms))))
 
 (defn checks [{checks :kaocha.spec.test.check/checks :as testable}]
   (let [checks (or checks [{}])]


### PR DESCRIPTION
`condp` using `cond`-like `:else`, resulting in a "no case found" error when `:kaocha.spec.test.check/syms` is a collection.