### PR TITLE
Correct documentation of `wrap-run` hooks

### DIFF
--- a/doc/10_hooks.md
+++ b/doc/10_hooks.md
@@ -172,10 +172,10 @@ Most of Kaocha's hooks have `pre-` and `post-` variants, but we don't have
 per-test level, in this case you can use `wrap-run` to "wrap" Kaocha's run
 function.
 
-In particular this wraps `kaocha.testable/-run`, so it receives a two argument function (the arguments are testable and test-plan), and should return such a function. `wrap-run` also receives the test-plan directly.
+In particular this wraps `kaocha.testable/-run`, so it receives a two argument function `run` (the arguments are testable and test-plan), and should return such a function.
 
 ``` clojure
-(defn my-wrap-run-hook [run _test-plan]
+(defn my-wrap-run-hook [run]
   (fn [testable test-plan]
     (println "about to run" (:kaocha.testable/id testable))
     (run testable test-plan)))


### PR DESCRIPTION
<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->

This documentation is misleading; `wrap-run` hooks do not receive two arguments but a single one, being `run`. We can see this here

https://github.com/lambdaisland/kaocha/blob/c3b4bfb78287988c1bdba8827c0e4369252ca8fd/src/kaocha/plugin/hooks.clj#L90-L91

Writing a wrap-run hook that takes two arguments will throw an `ArityException` when running tests. 
