### PR TITLE
Update preload docs

### DIFF
--- a/doc/08_plugins.md
+++ b/doc/08_plugins.md
@@ -164,7 +164,7 @@ Preload namespaces. Useful for loading specs and installing instrumentation.
 
 This plugin works for only Clojure namespaces. For ClojureScript namespaces, use
 the [`:preloads`
-functionality](https://cljs.github.io/api/compiler-options/preloads) of the
+functionality](https://clojurescript.org/reference/compiler-options#preloads) of the
 ClojureScript compiler.
 
 ## Debug

--- a/doc/08_plugins.md
+++ b/doc/08_plugins.md
@@ -162,6 +162,11 @@ Preload namespaces. Useful for loading specs and installing instrumentation.
  :kaocha.plugin.preloads/ns-names [my.acme.specs]}
 ```
 
+This plugin works for only Clojure namespaces. For ClojureScript namespaces, use
+the [`:preloads`
+functionality](https://cljs.github.io/api/compiler-options/preloads) of the
+ClojureScript compiler.
+
 ## Debug
 
 Inspect Kaocha's process by printing out a message at every single hook. This is

--- a/src/kaocha/plugin/preloads.clj
+++ b/src/kaocha/plugin/preloads.clj
@@ -4,8 +4,8 @@
   Useful for preloading specs and other instrumentation.
 
   This calls `require` on the given namespace names before loading any tests.
-  Only works for Clojure namespaces, for ClojureScript use the :preloads
-  functionality of the ClojureScript compiler."
+  This prlugin works for only Clojure namespaces. For ClojureScript namespaces,
+  use the :preloads functionality of the ClojureScript compiler."
   (:require [kaocha.plugin :refer [defplugin]]))
 
 (defplugin kaocha.plugin/preloads

--- a/src/kaocha/plugin/preloads.clj
+++ b/src/kaocha/plugin/preloads.clj
@@ -3,8 +3,10 @@
 
   Useful for preloading specs and other instrumentation.
 
-  This calls `require` on the given namespace names before loading any tests.
-  This prlugin works for only Clojure namespaces. For ClojureScript namespaces,
+  This plugin calls `require` on the given namespace names before loading any
+  tests.
+
+  This plugin works for only Clojure namespaces. For ClojureScript namespaces,
   use the :preloads functionality of the ClojureScript compiler."
   (:require [kaocha.plugin :refer [defplugin]]))
 


### PR DESCRIPTION
Two small changes:
* Tweak namespace docstring for kaocha.plugin.preloads. 
* Added note about the ClojureScript limitation to the plugins article.