### PR TITLE
Fix `Capability check for org.clojure/tools.cli` doc formatting

### DIFF
--- a/test/features/command_line/capability_check.feature
+++ b/test/features/command_line/capability_check.feature
@@ -1,4 +1,6 @@
-Feature: Capability check for org.clojure/tools.cli If a project's dependency
+Feature: Capability check for org.clojure/tools.cli
+
+  If a project's dependency
   pulls in an old version of tools.cli, then this may break command line flags
   of the form `--[no-]xxx`. Before starting the main command line runner, Kaocha
   verifies that tools.cli has the necessary capabilities.

--- a/test/features/command_line/capability_check.feature
+++ b/test/features/command_line/capability_check.feature
@@ -1,9 +1,9 @@
 Feature: Capability check for org.clojure/tools.cli
 
-  If a project's dependency
-  pulls in an old version of tools.cli, then this may break command line flags
-  of the form `--[no-]xxx`. Before starting the main command line runner, Kaocha
-  verifies that tools.cli has the necessary capabilities.
+  If a project's dependency pulls in an old version of tools.cli, then this may
+  break command line flags of the form `--[no-]xxx`. Before starting the main
+  command line runner, Kaocha verifies that tools.cli has the necessary
+  capabilities.
 
   Scenario: With an outdated tools.cli
     When I run `clojure -Sdeps '{:deps {org.clojure/tools.cli {:mvn/version "0.3.5"}}}' --main kaocha.runner`


### PR DESCRIPTION
The title and first sentence of this doc page are incorrectly combined: https://cljdoc.org/d/lambdaisland/kaocha/1.71.1119/doc/capability-check-for-org-clojure-tools-cli-if-a-project-s-dependency