### PR TITLE
Fix Windows crash when using `--watch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Fixed
 
+* Fix crash on Windows when using `--watch` with the default Beholder watcher.
+
 ## Changed
 
 # 1.72.1136 (2023-01-09 / d9f0728)

--- a/src/kaocha/watch.clj
+++ b/src/kaocha/watch.clj
@@ -303,7 +303,8 @@ errors as test errors."
              :watch-paths watch-paths
              :opts watcher-opts})
     (when-let [config-file (get-in config [:kaocha/cli-options :config-file])]
-      (when (.exists (io/file config-file))
+      (when (and (= watcher-type :hawk) ;;Only Hawk supports watching single files.
+                 (.exists (io/file config-file)))
         (watch! {:type watcher-type
                  :q q
                  :watch-paths #{config-file}


### PR DESCRIPTION
Not only does  watching individual files not work with Beholder, when using Beholder on Windows, it actually crashes. This PR disables watching `tests.edn` when using Beholder as as temporary fix, as proposed by @colin-p-hill in #270 .