### PR TITLE
Fix :each fixture wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Configuration errors and circular dependencies are reported as warnings, 
     rather than causing the entirewatcher to crash.
+- Fix bug added in [#384](https://github.com/lambdaisland/kaocha/issues/384):
+    assertions in the tail position of an each fixture would return the result
+    of the assertion instead of the testable object with the merged report data.
+    (thanks [@NoahTheDuke](https://github.com/NoahTheDuke))
 
 ## Changed
 

--- a/src/kaocha/type/var.clj
+++ b/src/kaocha/type/var.clj
@@ -17,10 +17,7 @@
   (println "Test ran without assertions. Did you forget an (is ...)?")
   (report/print-output m))
 
-(defn test-var [{test    :kaocha.var/test
-                 the-var :kaocha.var/var
-                 meta'   :kaocha.testable/meta
-                 :as     testable}]
+(defn test-var [test the-var]
   (binding [t/*testing-vars* (conj t/*testing-vars* the-var)]
     (t/do-report {:type :begin-test-var, :var the-var})
     (try
@@ -28,21 +25,24 @@
       (catch clojure.lang.ExceptionInfo e
         (when-not (:kaocha/fail-fast (ex-data e))
           (report/report-exception e)))
-      (catch Throwable e (report/report-exception e)))
-    (let [{::result/keys [pass error fail pending] :as result} (type/report-count)]
-      (when (= pass error fail pending 0)
-        (binding [testable/*fail-fast?* false
-                  testable/*test-location* {:file (:file meta') :line (:line meta')}]
-          (t/do-report {:type ::zero-assertions}))))
-    (t/do-report {:type :end-test-var, :var the-var})
-    (merge testable {:kaocha.result/count 1} (type/report-count))))
+      (catch Throwable e (report/report-exception e)))))
 
-(defmethod testable/-run :kaocha.type/var [{wrap :kaocha.testable/wrap
-                                            :as  testable} test-plan]
+(defmethod testable/-run :kaocha.type/var [{test    :kaocha.var/test
+                                            wrap    :kaocha.testable/wrap
+                                            the-var :kaocha.var/var
+                                            meta'   :kaocha.testable/meta
+                                            :as     testable} test-plan]
   (type/with-report-counters
-    (let [wrapped-test (fn [] (test-var testable))
+    (let [wrapped-test (fn [] (test-var test the-var))
           wrapped-test (reduce #(%2 %1) wrapped-test wrap)]
-      (wrapped-test))))
+      (wrapped-test)
+      (let [{::result/keys [pass error fail pending] :as result} (type/report-count)]
+        (when (= pass error fail pending 0)
+          (binding [testable/*fail-fast?* false
+                    testable/*test-location* {:file (:file meta') :line (:line meta')}]
+            (t/do-report {:type ::zero-assertions}))))
+      (t/do-report {:type :end-test-var, :var the-var})
+      (merge testable {:kaocha.result/count 1} (type/report-count)))))
 
 (s/def :kaocha.type/var (s/keys :req [:kaocha.testable/type
                                       :kaocha.testable/id

--- a/test/unit/kaocha/post_assertion_test.clj
+++ b/test/unit/kaocha/post_assertion_test.clj
@@ -1,0 +1,14 @@
+(ns kaocha.post-assertion-test
+  (:require [clojure.test :refer [deftest is use-fixtures]]))
+
+(defn- post-assertion-fixture
+  "Verify that an :each fixture that makes its own assertions doesn't
+  break join-fixtures wrapping."
+  [f]
+  (f)
+  (is (= true true)))
+
+(use-fixtures :each #'post-assertion-fixture)
+
+(deftest post-assertion-simple-test
+  (is (= 2 (+ 1 1))))


### PR DESCRIPTION
Moving the `type/report-count` portion of `testable/-run :var` into `test-var` wrapped it in the `join-fixtures` calls, meaning that the `is` assertion was in the tail position and returned the result (a boolean) instead of returning the merged `testable` object.

To fix, I've pulled the `type/report-count` portion back into `testable/-run :var` and have added a top-level test that fail without this change.

Closes [#384](https://github.com/lambdaisland/kaocha/issues/384)

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
