### PR TITLE
More babashka compat

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -35,5 +35,6 @@
   :dev
   {:extra-paths ["dev"]
    :extra-deps  {djblue/portal {:mvn/version "RELEASE"}}}
-  :bb 
-  {:extra-deps {nubank/matcher-combinators    {:mvn/version "3.5.1"}}}}}
+
+  :bb
+  {:extra-deps {nubank/matcher-combinators {:mvn/version "3.5.1"}}}}}

--- a/src/kaocha/classpath.bb
+++ b/src/kaocha/classpath.bb
@@ -1,54 +1,6 @@
 (ns kaocha.classpath
-  "This is the add-classpath function from Pomegranate 1.0.0, extracted so we
-  don't need to pull in Aether."
+  "On babashka we use bb's version of add-classpath"
   (:refer-clojure :exclude [add-classpath])
-  (:require [clojure.java.io :as io]))
+  (:require [babashka.classpath :as bbcp]))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Pomegranate
-
-#_(defn ensure-compiler-loader
-  "Ensures the clojure.lang.Compiler/LOADER var is bound to a DynamicClassLoader,
-  so that we can add to Clojure's classpath dynamically."
-  []
-  (when-not (bound? Compiler/LOADER)
-    (.bindRoot Compiler/LOADER (clojure.lang.DynamicClassLoader. (clojure.lang.RT/baseLoader)))))
-
-(defn- classloader-hierarchy
-  "Returns a seq of classloaders, with the tip of the hierarchy first.
-   Uses the current thread context ClassLoader as the tip ClassLoader
-   if one is not provided."
-  ([]
-   #_(ensure-compiler-loader)
-   #_(classloader-hierarchy (deref clojure.lang.Compiler/LOADER)))
-  ([tip]
-   #_(->> tip
-        (iterate #(.getParent ^ClassLoader %))
-        (take-while boolean))))
-
-(defn- modifiable-classloader?
-  "Returns true iff the given ClassLoader is of a type that satisfies
-   the dynapath.dynamic-classpath/DynamicClasspath protocol, and it can
-   be modified."
-  [cl]
-  #_(dp/addable-classpath? cl) 
-  false)
-
-(defn add-classpath
-  "A corollary to the (deprecated) `add-classpath` in clojure.core. This implementation
-   requires a java.io.File or String path to a jar file or directory, and will attempt
-   to add that path to the right classloader (with the search rooted at the current
-   thread's context classloader)."
-  ([jar-or-dir classloader]
-   #_(if-not (dp/add-classpath-url classloader (.toURL (.toURI (io/file jar-or-dir))))
-     (throw (IllegalStateException. (str classloader " is not a modifiable classloader")))))
-  ([jar-or-dir]
-   (let [classloaders (classloader-hierarchy)]
-     (if-let [cl (filter modifiable-classloader? classloaders)]
-       ;; Add to all classloaders that allow it. Brute force but doesn't hurt.
-       (run! #(add-classpath jar-or-dir %) cl)
-       (throw (IllegalStateException. (str "Could not find a suitable classloader to modify from "
-                                           classloaders)))))))
-
-;; /Pomegranate
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(def add-classpath bbcp/add-classpath)

--- a/src/kaocha/core_ext.clj
+++ b/src/kaocha/core_ext.clj
@@ -59,9 +59,8 @@
      (instance? clojure.lang.Var name) (.toSymbol ^clojure.lang.Var name)
      (instance? clojure.lang.Keyword name) (.sym ^clojure.lang.Keyword name)
      :else (throw (IllegalArgumentException. "no conversion to symbol"))))
-  ([ns name] (platform/if-babashka 
-               (clojure.core/symbol ns name)
-               (clojure.lang.Symbol/intern ns name))))
+  ([ns name]
+   (clojure.core/symbol ns name)))
 
 ;; 1.10 backport
 (when-not (resolve 'clojure.core/requiring-resolve)

--- a/src/kaocha/platform.clj
+++ b/src/kaocha/platform.clj
@@ -1,25 +1,12 @@
-(ns kaocha.platform "Utility functions for specific platforms.")
+(ns kaocha.platform
+  "Utility functions for specific platforms.")
 
-
-(defn on-windows? 
+(defn on-windows?
   "Return whether we're running on Windows."
   []
   (re-find #"Windows" (System/getProperty "os.name")))
-
 
 (defn on-posix?
   "Return whether we're running on a Posix system."
   []
   (re-find #"(?ix)(MacOS|Linux)" (System/getProperty "os.name")))
-
-(defn on-babashka?
-  "Return whether we're running on Babashka."
-  []
-  (boolean (System/getProperty "babashka.version")))
-
-
-(defmacro if-babashka 
-  [babashka-form clojure-form]
-  (if (on-babashka?)
-    babashka-form
-    clojure-form))

--- a/src/kaocha/systray.bb
+++ b/src/kaocha/systray.bb
@@ -1,0 +1,6 @@
+(ns kaocha.systray
+  "Null-implementation for babashka")
+
+
+(defn display-message
+  [title message urgency])

--- a/src/kaocha/systray.clj
+++ b/src/kaocha/systray.clj
@@ -1,0 +1,38 @@
+(ns kaocha.systray
+  (:import (java.nio.file Files)
+           (java.io IOException)
+           #_       (java.awt SystemTray
+                              TrayIcon
+                              TrayIcon$MessageType
+                              Toolkit)))
+
+(def tray-icon
+  "Creates a system tray icon."
+  (memoize
+   (fn [icon-path]
+     #_(let [^java.awt.Toolkit toolkit (Toolkit/getDefaultToolkit)
+             tray-icon (-> toolkit
+                           (.getImage ^String icon-path)
+                           (TrayIcon. "Kaocha Notification"))]
+         (doto (SystemTray/getSystemTray)
+           (.add tray-icon))
+         tray-icon))))
+
+(defn display-message
+  "Use Java's built-in functionality to display a notification.
+
+  Not preferred over shelling out because the built-in notification sometimes
+  looks out of place, and isn't consistently available on Linux."
+  [title message urgency]
+  #_(try
+      (.displayMessage (tray-icon "kaocha/clojure_logo.png")
+                       title
+                       message
+                       (get {:error TrayIcon$MessageType/ERROR
+                             :info TrayIcon$MessageType/INFO}
+                            urgency))
+      :ok
+      (catch java.awt.HeadlessException _e
+        :headless)
+      (catch java.lang.UnsupportedOperationException _e
+        :unsupported)))


### PR DESCRIPTION
Generally try to move towards code that simply works on both platforms, when that's not possible factor out platform-specific code in platform-specific files (.bb vs .clj).

This way `if-babashka` isn't needed.

Note that normally we have a `.platform` namespace with all the platform specific bits, e.g. https://github.com/lambdaisland/uri/tree/main/src/lambdaisland/uri , but `kaocha.platform` was already taken, and I ended up introducing separate `kaocha.classpath` and `kaocha.systray` split namespaces. Maybe `kaocha.platform.systray` and `kaocha.platform.classpath` would be better.

`watch-load-error-test` seems to hang right now, probably due to the exception handling refactoring. I like how it simplifies things, but it does introduce a bit of change. I think relying on specific ex-data keys is a more useful contract than looking for a specific (nested) compiler error class.

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
