### PR TITLE
Load namespaces first required with :as-alias

### DIFF
--- a/src/kaocha/ns.clj
+++ b/src/kaocha/ns.clj
@@ -9,7 +9,8 @@
             [kaocha.type :as type]))
 
 (defn required-ns [ns-name]
-  (when-not (find-ns ns-name)
+  (when-not (and (find-ns ns-name)
+                 (contains? (loaded-libs) (symbol ns-name)))
     (require ns-name))
   (try
     (the-ns ns-name)


### PR DESCRIPTION
Ensure libs are loaded (and don't just have an alias) before skipping them in our loading code in kaocha.ns. Fixes #390.

