### PR TITLE
332 plugin kaocha plugin profiling does not run when watch is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Fixed
 
+- The watcher now prints the output from plugins, eg. `bin/kaocha --watch --plugin kaocha.plugin/profiling` 
+
 ## Changed
 
 # 1.82.1306 (2023-03-30 / 40698c5)

--- a/deps.edn
+++ b/deps.edn
@@ -27,10 +27,10 @@
 
   :feature-docs
   {:extra-deps
-   {lambdaisland/kaocha-cucumber  {:mvn/version "0.0-53" :exclusions [lambdaisland/kaocha]}
-    lambdaisland/open-source {:git/url "https://github.com/lambdaisland/open-source"
+   {lambdaisland/kaocha-cucumber {:mvn/version "0.0-53" :exclusions [lambdaisland/kaocha]}
+    lambdaisland/open-source     {:git/url "https://github.com/lambdaisland/open-source"
                               :git/sha "f42c1c48a3ca3376d9af37aa4cbcd95ba968b66f"
-                              #_#_:local/root "../open-source"}}}
+                                  #_#_:local/root "../open-source"}}}
 
   :dev
   {:extra-paths ["dev"]

--- a/src/kaocha/watch.clj
+++ b/src/kaocha/watch.clj
@@ -52,7 +52,7 @@
                    (assoc ::tracker tracker)
                    (update :kaocha/plugins #(cons ::plugin %)))
         result (try
-                 (api/run config)
+                 (plugin/run-hook :kaocha.hooks/post-summary (api/run config))
                  (catch Throwable t
                    (println "[watch] Fatal error in test run" t)))]
     (println)

--- a/test/unit/kaocha/watch_test.clj
+++ b/test/unit/kaocha/watch_test.clj
@@ -133,12 +133,16 @@
 
     (is (str/includes?
            @out-str
-          (str/replace
+          (str/replace 
+            (str/replace
 
-              "[(F)]\n\nFAIL in foo.bar-test/xxx-test (bar_test.clj:1)\nExpected:\n  :xxx\nActual:\n  -:xxx +:yyy\n1 tests, 1 assertions, 1 failures.\n\n[watch] Reloading #{foo.bar-test}\n[watch] Re-running failed tests #{:foo.bar-test/xxx-test}\n[(F)]\n\nFAIL in foo.bar-test/xxx-test (bar_test.clj:1)\nExpected:\n  :xxx\nActual:\n  -:xxx +:zzz"
+              "[(F)]\n\nFAIL in foo.bar-test/xxx-test (bar_test.clj:1)\nExpected:\n  :xxx\nActual:\n  -:xxx +:zzz\n1 tests, 1 assertions, 1 failures.\n\nbin/kaocha --config-file PATH --focus 'foo.bar-test/xxx-test'\n\n[watch] Reloading #{foo.bar-test}\n[watch] Re-running failed tests #{:foo.bar-test/xxx-test}\n[(F)]\n\nFAIL in foo.bar-test/xxx-test (bar_test.clj:1)\nExpected:\n  :xxx\nActual:\n  -:xxx +:zzz"
 
                      "foo"
-                     prefix)))))
+                     prefix)
+            "PATH"
+            (str config-file)
+            )))))
 
 (deftest ignore-files-merged
   (let [{:keys [_config-file test-dir] :as m} (integration/test-dir-setup {})]

--- a/test/unit/kaocha/watch_test.clj
+++ b/test/unit/kaocha/watch_test.clj
@@ -132,17 +132,14 @@
     (Thread/sleep 100)
 
     (is (str/includes?
-           @out-str
+          @out-str
           (str/replace 
             (str/replace
-
-              "[(F)]\n\nFAIL in foo.bar-test/xxx-test (bar_test.clj:1)\nExpected:\n  :xxx\nActual:\n  -:xxx +:zzz\n1 tests, 1 assertions, 1 failures.\n\nbin/kaocha --config-file PATH --focus 'foo.bar-test/xxx-test'\n\n[watch] Reloading #{foo.bar-test}\n[watch] Re-running failed tests #{:foo.bar-test/xxx-test}\n[(F)]\n\nFAIL in foo.bar-test/xxx-test (bar_test.clj:1)\nExpected:\n  :xxx\nActual:\n  -:xxx +:zzz"
-
-                     "foo"
-                     prefix)
+              "[(F)]\n\nFAIL in foo.bar-test/xxx-test (bar_test.clj:1)\nExpected:\n  :xxx\nActual:\n  -:xxx +:yyy\n1 tests, 1 assertions, 1 failures.\n\nbin/kaocha --config-file PATH --focus 'foo.bar-test/xxx-test'\n\n[watch] Reloading #{foo.bar-test}\n[watch] Re-running failed tests #{:foo.bar-test/xxx-test}\n[(F)]\n\nFAIL in foo.bar-test/xxx-test (bar_test.clj:1)\nExpected:\n  :xxx\nActual:\n  -:xxx +:zzz"
+              "foo"
+              prefix)
             "PATH"
-            (str config-file)
-            )))))
+            (str config-file))))))
 
 (deftest ignore-files-merged
   (let [{:keys [_config-file test-dir] :as m} (integration/test-dir-setup {})]


### PR DESCRIPTION
Wrap the callsite to api/run in the watcher with the post-summary hook, exactly as in the runner.
