### PR TITLE
Fix cljdocs again

### DIFF
--- a/src/kaocha/plugin/capture_output.cljc
+++ b/src/kaocha/plugin/capture_output.cljc
@@ -1,5 +1,6 @@
 (ns kaocha.plugin.capture-output
-  (:require [clojure.java.io :as io]
+  (:require 
+    #?(:clj [clojure.java.io :as io])
             [kaocha.hierarchy :as hierarchy]
             [kaocha.plugin :as plugin :refer [defplugin]]
             [kaocha.testable :as testable])


### PR DESCRIPTION
Quick fix to address a Cljdoc issue caused by the analysis trying to interpret one of our namespaces, moved to a `.cljc` with ClojureScript.