### PR TITLE
Fix Cljdocs (again)

### DIFF
--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -1,0 +1,1 @@
+{:cljdoc/languages ["clj"]}

--- a/src/kaocha/plugin/capture_output.cljc
+++ b/src/kaocha/plugin/capture_output.cljc
@@ -1,9 +1,9 @@
 (ns kaocha.plugin.capture-output
   (:require 
-    #?(:clj [clojure.java.io :as io])
-            [kaocha.hierarchy :as hierarchy]
-            [kaocha.plugin :as plugin :refer [defplugin]]
-            [kaocha.testable :as testable])
+    [clojure.java.io :as io]
+    [kaocha.hierarchy :as hierarchy]
+    [kaocha.plugin :as plugin :refer [defplugin]]
+    [kaocha.testable :as testable])
   (:import (java.io ByteArrayOutputStream
                     FileOutputStream
                     OutputStream


### PR DESCRIPTION
I realized my quick fix won't work because the other namespaces aren't available in ClojureScript either. So this change will prevent Cljdocs from trying to analyze Kaocha as a ClojureScript project.