### PR TITLE
Update Beholder to improve support for certain editors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 
 ## Fixed
+* Fix issue with `--watch` and Neovim by bumping Beholder to `1.0.2`
 
 ## Changed
 

--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
   org.tcrawley/dynapath        {:mvn/version "1.1.0"}
   slingshot/slingshot          {:mvn/version "0.12.2"}
   hawk/hawk                    {:mvn/version "0.2.11"}
-  com.nextjournal/beholder     {:mvn/version "1.0.1"}
+  com.nextjournal/beholder     {:mvn/version "1.0.2"}
   expound/expound              {:mvn/version "0.9.0"}
   aero/aero                    {:mvn/version "1.1.6"}
   progrock/progrock            {:mvn/version "0.1.2"}


### PR DESCRIPTION
Beholder released a fix for certain editors that create a new file and then delete instead of modify. I believe Vim and Neovim do this when `noswapfile` and either `backupcopy=no` or `backupcopy=auto` are set, but other editors probably do it too.

Sometimes these creation events would be dropped because the file exists already. I haven't noticed this problem when using --watch with Neovim, but it may depend on timing and thus may be highly platform-, version- or setup-specific. Also, I consider this a safe change to make without reproducing the initial issue.

