### PR TITLE
add config for zero assertions switcher in config and cli args

### DIFF
--- a/doc/03_configuration.md
+++ b/doc/03_configuration.md
@@ -20,6 +20,7 @@ Here's an example test configuration with a single test suite:
                                        :kaocha/source-paths  ["src"]
                                        :kaocha/test-paths    ["test/unit"]}]
  :kaocha/fail-fast?                  false
+ :kaocha/mute-zero-assertion?        true
  :kaocha/color?                      true
  :kaocha/reporter                    [kaocha.report/dots]
  :kaocha/plugins                     [:kaocha.plugin/randomize

--- a/doc/03_configuration.md
+++ b/doc/03_configuration.md
@@ -20,7 +20,6 @@ Here's an example test configuration with a single test suite:
                                        :kaocha/source-paths  ["src"]
                                        :kaocha/test-paths    ["test/unit"]}]
  :kaocha/fail-fast?                  false
- :kaocha/mute-zero-assertion?        true
  :kaocha/color?                      true
  :kaocha/reporter                    [kaocha.report/dots]
  :kaocha/plugins                     [:kaocha.plugin/randomize

--- a/doc/clojure_test/assertions.md
+++ b/doc/clojure_test/assertions.md
@@ -32,6 +32,12 @@ FAIL in sample-test/my-test (sample_test.clj:4)
 Test ran without assertions. Did you forget an (is ...)?
 ```
 
+### Missing assertions are configurable
+
+There are two ways to disable this detection:
+
+* Enable `:mute-zero-assertion?` at `tests.edn`.
+* Use `--mute-zero-assertion` in command line argument.
 
 
 ## Detecting single argument `=`

--- a/doc/clojure_test/assertions.md
+++ b/doc/clojure_test/assertions.md
@@ -37,6 +37,7 @@ Test ran without assertions. Did you forget an (is ...)?
 There are two ways to disable this detection:
 
 * Add `:kaocha/warnings {:zero-assertions :silent}` into `tests.edn`.
+* Add `:kaocha/warnings {:zero-tests :error}` into `tests.edn`.
 
 ## Detecting single argument `=`
 

--- a/doc/clojure_test/assertions.md
+++ b/doc/clojure_test/assertions.md
@@ -36,9 +36,7 @@ Test ran without assertions. Did you forget an (is ...)?
 
 There are two ways to disable this detection:
 
-* Enable `:mute-zero-assertion?` at `tests.edn`.
-* Use `--mute-zero-assertion` in command line argument.
-
+* Add `:kaocha/warnings {:zero-assertions :silent}` into `tests.edn`.
 
 ## Detecting single argument `=`
 

--- a/src/kaocha/api.clj
+++ b/src/kaocha/api.clj
@@ -92,7 +92,7 @@
       (let [config     (plugin/run-hook :kaocha.hooks/config config)
             color?     (:kaocha/color? config)
             fail-fast? (:kaocha/fail-fast? config)
-            mute-zero-assertion? (:kaocha/mute-zero-assertion? config)
+            warnings (:kaocha/warnings config)
             history    (atom [])]
         (binding [*active?*               true
                   testable/*fail-fast?*   fail-fast?
@@ -103,7 +103,7 @@
             (let [config (resolve-reporter config)]
               (let [test-plan (test-plan config)]
 
-                (when mute-zero-assertion?
+                (when (= (:zero-assertions warnings) :silent)
                   (hierarchy/underive! :kaocha.type.var/zero-assertions :kaocha/known-key)
                   (hierarchy/underive! :kaocha.type.var/zero-assertions :kaocha/fail-type))
 

--- a/src/kaocha/api.clj
+++ b/src/kaocha/api.clj
@@ -115,8 +115,13 @@
                                               " Check for misspelled settings in your Kaocha test configuration"
                                               " or incorrect focus or skip filters.")
                                          (count (testable/test-seq-with-skipped test-plan))))
-                    (output/warn (str "No tests were found. This may be an issue in your Kaocha test configuration."
-                                      " To investigate, check the :test-paths and :ns-patterns keys in tests.edn.")))
+                    (if (= (:zero-tests warnings) :error)
+                      (do
+                        (output/error (str "No tests were found. This may be an issue in your Kaocha test configuration."
+                                           " To investigate, check the :test-paths and :ns-patterns keys in tests.edn."))
+                        (throw+ {:kaocha/early-exit 253}))
+                      (output/warn (str "No tests were found. This may be an issue in your Kaocha test configuration."
+                                        " To investigate, check the :test-paths and :ns-patterns keys in tests.edn."))))
                   (throw+ {:kaocha/early-exit 0}))
 
                 (when (find-ns 'matcher-combinators.core)

--- a/src/kaocha/api.clj
+++ b/src/kaocha/api.clj
@@ -92,6 +92,7 @@
       (let [config     (plugin/run-hook :kaocha.hooks/config config)
             color?     (:kaocha/color? config)
             fail-fast? (:kaocha/fail-fast? config)
+            mute-zero-assertion? (:kaocha/mute-zero-assertion? config)
             history    (atom [])]
         (binding [*active?*               true
                   testable/*fail-fast?*   fail-fast?
@@ -101,6 +102,10 @@
           (with-bindings (config/binding-map config)
             (let [config (resolve-reporter config)]
               (let [test-plan (test-plan config)]
+
+                (when mute-zero-assertion?
+                  (hierarchy/underive! :kaocha.type.var/zero-assertions :kaocha/known-key)
+                  (hierarchy/underive! :kaocha.type.var/zero-assertions :kaocha/fail-type))
 
                 (when-not (some #(or (hierarchy/leaf? %)
                                      (::testable/load-error %))
@@ -112,7 +117,7 @@
                                          (count (testable/test-seq-with-skipped test-plan))))
                     (output/warn (str "No tests were found. This may be an issue in your Kaocha test configuration."
                                       " To investigate, check the :test-paths and :ns-patterns keys in tests.edn.")))
-                  (throw+ {:kaocha/early-exit 0 }))
+                  (throw+ {:kaocha/early-exit 0}))
 
                 (when (find-ns 'matcher-combinators.core)
                   (require 'kaocha.matcher-combinators))

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -195,7 +195,6 @@
      config
      (read-config nil opts))))
 
-
 (defn apply-cli-opts [config options]
   (cond-> config
     (some? (:fail-fast options))  (assoc :kaocha/fail-fast? (:fail-fast options))
@@ -224,10 +223,10 @@
   "Applies command-line options and arguments to the configuration."
   [config cli-opts cli-args]
   (cond-> config
-      cli-opts (apply-cli-opts cli-opts)
-      cli-args (apply-cli-args cli-args)))
+    cli-opts (apply-cli-opts cli-opts)
+    cli-args (apply-cli-args cli-args)))
 
-(defn find-config-and-warn 
+(defn find-config-and-warn
   [config-file]
   (let [final-config-file (or config-file "tests.edn")]
     (when (not (.exists (io/file (or config-file "tests.edn"))))
@@ -241,13 +240,13 @@
 (defn validate!
   "Validates the configuration, printing any warnings and errors and possibly throwing."
   [config]
-    (try
-      (specs/assert-spec :kaocha/config config)
-      config
-      (catch AssertionError e
-        (output/error "Invalid configuration file:\n"
-                      (.getMessage e))
-        (throw+ {:kaocha/early-exit 252}))))
+  (try
+    (specs/assert-spec :kaocha/config config)
+    config
+    (catch AssertionError e
+      (output/error "Invalid configuration file:\n"
+                    (.getMessage e))
+      (throw+ {:kaocha/early-exit 252}))))
 
 (defn load-config-for-cli-and-validate
   "Loads config from config-file, factoring in profile specified using profile,

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -78,7 +78,7 @@
                 reporter
                 color?
                 fail-fast?
-                mute-zero-assertion?
+                warnings
                 diff-style
                 randomize?
                 capture-output?
@@ -89,15 +89,15 @@
       tests                   (assoc :kaocha/tests (vary-meta tests assoc :replace true))
       plugins                 (assoc :kaocha/plugins plugins)
       reporter                (assoc :kaocha/reporter (vary-meta reporter assoc :replace true))
+      warnings                (assoc :kaocha/warnings warnings)
       bindings                (assoc :kaocha/bindings bindings)
       (some? color?)          (assoc :kaocha/color? color?)
       (some? fail-fast?)      (assoc :kaocha/fail-fast? fail-fast?)
-      (some? mute-zero-assertion?)      (assoc :kaocha/mute-zero-assertion? mute-zero-assertion?)
       (some? diff-style)      (assoc :kaocha/diff-style diff-style)
       (some? watch?)          (assoc :kaocha/watch? watch?)
       (some? randomize?)      (assoc :kaocha.plugin.randomize/randomize? randomize?)
       (some? capture-output?) (assoc :kaocha.plugin.capture-output/capture-output? capture-output?)
-      :->                     (merge (dissoc config :tests :plugins :reporter :color? :fail-fast? :mute-zero-assertion? :watch? :randomize?)))))
+      :->                     (merge (dissoc config :tests :plugins :reporter :warnings :color? :fail-fast? :watch? :randomize?)))))
 
 (defmethod aero/reader 'kaocha [_opts _tag value]
   (output/warn (format "The #kaocha reader literal is deprecated, please change it to %s." current-reader))
@@ -200,7 +200,6 @@
 (defn apply-cli-opts [config options]
   (cond-> config
     (some? (:fail-fast options))  (assoc :kaocha/fail-fast? (:fail-fast options))
-    (some? (:mute-zero-assertion options))  (assoc :kaocha/mute-zero-assertion? (:mute-zero-assertion options))
     (:reporter options)           (assoc :kaocha/reporter (:reporter options))
     (:watch options)              (assoc :kaocha/watch? (:watch options))
     (some? (:color options))      (assoc :kaocha/color? (:color options))

--- a/src/kaocha/config.clj
+++ b/src/kaocha/config.clj
@@ -78,6 +78,7 @@
                 reporter
                 color?
                 fail-fast?
+                mute-zero-assertion?
                 diff-style
                 randomize?
                 capture-output?
@@ -91,11 +92,12 @@
       bindings                (assoc :kaocha/bindings bindings)
       (some? color?)          (assoc :kaocha/color? color?)
       (some? fail-fast?)      (assoc :kaocha/fail-fast? fail-fast?)
+      (some? mute-zero-assertion?)      (assoc :kaocha/mute-zero-assertion? mute-zero-assertion?)
       (some? diff-style)      (assoc :kaocha/diff-style diff-style)
       (some? watch?)          (assoc :kaocha/watch? watch?)
       (some? randomize?)      (assoc :kaocha.plugin.randomize/randomize? randomize?)
       (some? capture-output?) (assoc :kaocha.plugin.capture-output/capture-output? capture-output?)
-      :->                     (merge (dissoc config :tests :plugins :reporter :color? :fail-fast? :watch? :randomize?)))))
+      :->                     (merge (dissoc config :tests :plugins :reporter :color? :fail-fast? :mute-zero-assertion? :watch? :randomize?)))))
 
 (defmethod aero/reader 'kaocha [_opts _tag value]
   (output/warn (format "The #kaocha reader literal is deprecated, please change it to %s." current-reader))
@@ -198,6 +200,7 @@
 (defn apply-cli-opts [config options]
   (cond-> config
     (some? (:fail-fast options))  (assoc :kaocha/fail-fast? (:fail-fast options))
+    (some? (:mute-zero-assertion options))  (assoc :kaocha/mute-zero-assertion? (:mute-zero-assertion options))
     (:reporter options)           (assoc :kaocha/reporter (:reporter options))
     (:watch options)              (assoc :kaocha/watch? (:watch options))
     (some? (:color options))      (assoc :kaocha/color? (:color options))

--- a/src/kaocha/hierarchy.clj
+++ b/src/kaocha/hierarchy.clj
@@ -8,6 +8,11 @@
   [tag parent]
   (alter-var-root #'hierarchy derive tag parent))
 
+(defn underive!
+  "Add a parent/child relationship to kaocha's keyword hierarchy."
+  [tag parent]
+  (alter-var-root #'hierarchy underive tag parent))
+
 (derive! :fail :kaocha/fail-type)
 (derive! :error :kaocha/fail-type)
 

--- a/src/kaocha/report.clj
+++ b/src/kaocha/report.clj
@@ -99,7 +99,6 @@
             [kaocha.plugin.capture-output :as capture]
             [kaocha.stacktrace :as stacktrace]
             [kaocha.testable :as testable]
-            [kaocha.testable :as testable]
             [kaocha.util :as util]
             [slingshot.slingshot :refer [throw+]]))
 
@@ -424,6 +423,7 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 
 (def dots
   "Reporter that prints progress as a sequence of dots and letters."

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -42,8 +42,7 @@
                     (symbol "kaocha.report" s))))
     :assoc-fn accumulate]
    [nil "--diff-style STYLE"    "The style of diff to print on failing tests, either :none or :deep"
-    :parse-fn parse-kw
-    ]
+    :parse-fn parse-kw]
    [nil "--plugin KEYWORD"      "Load the given plugin."
     :parse-fn (fn [s]
                 (let [kw (parse-kw s)]
@@ -151,8 +150,8 @@
           config-file                                               (config/find-config-and-warn config-file)
           ;; Initial configuration load to determine plugins.
           config                                                    (->  (config/load-config config-file (if profile {:profile profile} {}))
-                                                                        (config/apply-cli {} (map parse-kw arguments))
-                                                                        (config/validate!))
+                                                                         (config/apply-cli {} (map parse-kw arguments))
+                                                                         (config/validate!))
           plugin-chain                                              (plugin/load-all (concat (:kaocha/plugins config) plugin))
           cli-options                                               (plugin/run-hook* plugin-chain :kaocha.hooks/cli-options cli-options)
 

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -32,7 +32,6 @@
    [nil  "--print-test-plan"    "Load tests, build up a test plan, then print out the test plan and exit."]
    [nil  "--print-result"       "Print the test result map as returned by the Kaocha API."]
    [nil  "--[no-]fail-fast"     "Stop testing after the first failure."]
-   [nil  "--[no-]mute-zero-assertion"     "Stop raising failure when there is no assertion in test."]
    [nil  "--[no-]color"         "Enable/disable ANSI color codes in output. Defaults to true."]
    [nil  "--[no-]watch"         "Watch filesystem for changes and re-run tests."]
    [nil  "--reporter SYMBOL"    "Change the test reporter, can be specified multiple times."

--- a/src/kaocha/runner.clj
+++ b/src/kaocha/runner.clj
@@ -32,6 +32,7 @@
    [nil  "--print-test-plan"    "Load tests, build up a test plan, then print out the test plan and exit."]
    [nil  "--print-result"       "Print the test result map as returned by the Kaocha API."]
    [nil  "--[no-]fail-fast"     "Stop testing after the first failure."]
+   [nil  "--[no-]mute-zero-assertion"     "Stop raising failure when there is no assertion in test."]
    [nil  "--[no-]color"         "Enable/disable ANSI color codes in output. Defaults to true."]
    [nil  "--[no-]watch"         "Watch filesystem for changes and re-run tests."]
    [nil  "--reporter SYMBOL"    "Change the test reporter, can be specified multiple times."

--- a/src/kaocha/specs.clj
+++ b/src/kaocha/specs.clj
@@ -22,7 +22,7 @@
 
 (spec/def :kaocha/fail-fast? boolean?)
 
-(spec/def :kaocha/mute-zero-assertion? boolean?)
+(spec/def :kaocha/warnings (spec/map-of #{:zero-assertions} #{:silent :error}))
 
 (spec/def :kaocha/watch? boolean?)
 
@@ -36,7 +36,7 @@
   (spec/keys :opt [:kaocha/reporter
                    :kaocha/color?
                    :kaocha/fail-fast?
-                   :kaocha/mute-zero-assertion?
+                   :kaocha/warnings
                    :kaocha/watch?
                    :kaocha/plugins]))
 

--- a/src/kaocha/specs.clj
+++ b/src/kaocha/specs.clj
@@ -22,7 +22,7 @@
 
 (spec/def :kaocha/fail-fast? boolean?)
 
-(spec/def :kaocha/warnings (spec/map-of #{:zero-assertions} #{:silent :error}))
+(spec/def :kaocha/warnings (spec/map-of #{:zero-assertions :zero-tests} #{:silent :error}))
 
 (spec/def :kaocha/watch? boolean?)
 

--- a/src/kaocha/specs.clj
+++ b/src/kaocha/specs.clj
@@ -22,6 +22,8 @@
 
 (spec/def :kaocha/fail-fast? boolean?)
 
+(spec/def :kaocha/mute-zero-assertion? boolean?)
+
 (spec/def :kaocha/watch? boolean?)
 
 (spec/def :kaocha/plugins (spec/coll-of keyword?))
@@ -34,7 +36,7 @@
   (spec/keys :opt [:kaocha/reporter
                    :kaocha/color?
                    :kaocha/fail-fast?
-                   :kaocha/zero-assertion?
+                   :kaocha/mute-zero-assertion?
                    :kaocha/watch?
                    :kaocha/plugins]))
 

--- a/src/kaocha/specs.clj
+++ b/src/kaocha/specs.clj
@@ -27,28 +27,29 @@
 (spec/def :kaocha/plugins (spec/coll-of keyword?))
 
 (spec/def :kaocha/reporter (spec/or :fn      (s-fspec :args (spec/cat :m map?))
-                              :symbol  symbol?
-                              :symbols (spec/coll-of symbol? :kind vector?)))
+                                    :symbol  symbol?
+                                    :symbols (spec/coll-of symbol? :kind vector?)))
 
 (spec/def :kaocha/global-opts
   (spec/keys :opt [:kaocha/reporter
-                :kaocha/color?
-                :kaocha/fail-fast?
-                :kaocha/watch?
-                :kaocha/plugins]))
+                   :kaocha/color?
+                   :kaocha/fail-fast?
+                   :kaocha/zero-assertion?
+                   :kaocha/watch?
+                   :kaocha/plugins]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; config
 
 (spec/def :kaocha/config (spec/merge :kaocha/global-opts
-                               (spec/keys :opt [:kaocha/tests])))
+                                     (spec/keys :opt [:kaocha/tests])))
 
 (spec/def :kaocha/tests (spec/coll-of :kaocha/testable))
 
 (spec/def :kaocha/testable (spec/keys :req [:kaocha.testable/type
-                                      :kaocha.testable/id]
-                                :opt [:kaocha.testable/meta
-                                      :kaocha.testable/wrap]))
+                                            :kaocha.testable/id]
+                                      :opt [:kaocha.testable/meta
+                                            :kaocha.testable/wrap]))
 
 (spec/def :kaocha/source-paths (spec/coll-of string?))
 
@@ -77,43 +78,43 @@
 
 (spec/def :kaocha/test-plan
   (spec/merge :kaocha/global-opts
-           (spec/keys :opt [:kaocha.test-plan/tests])))
+              (spec/keys :opt [:kaocha.test-plan/tests])))
 
 (spec/def :kaocha.test-plan/tests (spec/coll-of :kaocha.test-plan/testable))
 
 (spec/def :kaocha.test-plan/testable (spec/merge :kaocha/testable
-                                           (spec/keys :req []
-                                                   :opt [:kaocha.testable/desc
-                                                         :kaocha.test-plan/tests
-                                                         :kaocha.testable/load-error])))
+                                                 (spec/keys :req []
+                                                            :opt [:kaocha.testable/desc
+                                                                  :kaocha.test-plan/tests
+                                                                  :kaocha.testable/load-error])))
 
 (spec/def :kaocha.testable/load-error (s-with-gen
-                                    #(instance? Throwable %)
-                                    #(s-gen #{(ex-info "load error" {:oops "not good"})})))
+                                       #(instance? Throwable %)
+                                       #(s-gen #{(ex-info "load error" {:oops "not good"})})))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; result
 
 (spec/def :kaocha/result
   (spec/merge :kaocha/global-opts
-           (spec/keys :opt [:kaocha.result/tests])))
+              (spec/keys :opt [:kaocha.result/tests])))
 
 (spec/def :kaocha.result/tests (spec/coll-of :kaocha.result/testable))
 
 (spec/def :kaocha.result/testable (spec/merge :kaocha.test-plan/testable
-                                        (spec/keys :opt [:kaocha.result/count
-                                                      :kaocha.result/tests
-                                                      :kaocha.result/pass
-                                                      :kaocha.result/error
-                                                      :kaocha.result/fail
-                                                      :kaocha.result/out
-                                                      :kaocha.result/err
-                                                      :kaocha.result/time])))
+                                              (spec/keys :opt [:kaocha.result/count
+                                                               :kaocha.result/tests
+                                                               :kaocha.result/pass
+                                                               :kaocha.result/error
+                                                               :kaocha.result/fail
+                                                               :kaocha.result/out
+                                                               :kaocha.result/err
+                                                               :kaocha.result/time])))
 
 (spec/def ::small-int (s-with-gen
-                    nat-int?
-                    (constantly (or (some-> (resolve `clojure.test.check.generatorspec/small-integer) deref)
-                                    (s-gen nat-int?)))))
+                       nat-int?
+                       (constantly (or (some-> (resolve `clojure.test.check.generatorspec/small-integer) deref)
+                                       (s-gen nat-int?)))))
 
 (spec/def :kaocha.result/count ::small-int)
 (spec/def :kaocha.result/pass ::small-int)
@@ -145,7 +146,7 @@
   (spec/def ::stc/num-tests (spec/nilable nat-int?))
   (spec/def ::stc/max-size (spec/nilable nat-int?))
   (spec/def ::stc/opts (spec/nilable (spec/keys :opt-un [::stc/num-tests
-                                                ::stc/max-size]))))
+                                                         ::stc/max-size]))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; helpers


### PR DESCRIPTION
## This is for #162 

kaocha's default behavior will let the tests fail if there are no `is` in assertion. 
```
laurencechen qqq $ ./bin/kaocha  
[(F)]
Randomized with --seed 1954406926

FAIL in qqq-test/example-test (qqq_test.clj:5)
Test ran without assertions. Did you forget an (is ...)?
1 tests, 1 assertions, 1 failures.
```

With this MR, we now support a new config/cli args to switch off the `zero-assertions`

Example of `tests.edn`

```
#kaocha/v1
{:tests [{:id          :unit
          :test-paths  ["test" "src"]
          :ns-patterns [".*"]}]
:warnings {:zero-assertions :silent}
}
```

## This MR can also fix #211 
Example of `tests.edn`

```
#kaocha/v1
{:tests [{:id          :unit
          :test-paths  ["test" "src"]
          :ns-patterns [".*"]}]
:warnings {:zero-tests :error}
}
```
;; => Results
<img width="1003" alt="截圖 2023-04-21 下午4 55 36" src="https://user-images.githubusercontent.com/3061798/233592646-923cb987-437b-412f-b98a-110303066018.png">

