### PR TITLE
Feature: exec-args support for print-config & print-test-plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Added
 
+- Expose `:print-config true` and `:print-test-plan true` to Clojure CLI -X
+  invocations.
+
 ## Fixed
 
 ## Changed

--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ of tests skipped. You could save that configuration with an additional alias:
 If you wanted to turn off `fail-fast` temporarily, you could run `clojure
 -X:watch-test :fail-fast? false`
 
+You can also pass exec-args on the command line like so:
+
+`clojure -X:test :print-config true :kaocha.plugin.randomize/seed 603964682`
 
 ### Babashka
 


### PR DESCRIPTION
This adds support for the following exec-args when using the Clojure CLI exec-fn / -X invocation method:

- `:print-config true`
- `:print-test-plan true`

Fixes #401 