### PR TITLE
Clean up output of :print-invocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 node_modules
 package-lock.json
 .store
+deps.local.edn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Fixed
 
+- Get rid of extra space in output when using the `:print-invocations` plugin
+
 ## Changed
 
 - Bump tools.cli to 1.0.219

--- a/src/kaocha/plugin/print_invocations.clj
+++ b/src/kaocha/plugin/print_invocations.clj
@@ -16,26 +16,28 @@
       (doseq [test (testable/test-seq results)]
         (if (and (not (seq (::result/tests test))) (result/failed? test))
           (let [id (str (::testable/id test))]
-            (println "bin/kaocha"
-                     (str/join
-                      " "
-                      (mapcat (fn [[k v]]
-                                (cond
-                                  (vector? v)
-                                  (mapcat (fn [v] [(str "--" (name k)) v]) v)
-                                  
-                                  (true? v)
-                                  [(str "--" (name k))]
-                                  
-                                  (false? v)
-                                  [(str "--no-" (name k))]
-                                  
-                                  :else
-                                  [(str "--" (name k))  v]))
-                              (cond-> (dissoc (:kaocha/cli-options results) :focus)
-                                (= "tests.edn" (:config-file (:kaocha/cli-options results)))
-                                (dissoc :config-file))))
-                     "--focus"
-                     (str
-                      "'" (cond-> id (= (first id) \:) (subs 1)) "'"))))))
+            (println
+             (str/join
+              " "
+              (-> ["bin/kaocha"]
+                  (into
+                   (mapcat (fn [[k v]]
+                             (cond
+                               (vector? v)
+                               (mapcat (fn [v] [(str "--" (name k)) v]) v)
+
+                               (true? v)
+                               [(str "--" (name k))]
+
+                               (false? v)
+                               [(str "--no-" (name k))]
+
+                               :else
+                               [(str "--" (name k))  v]))
+                           (cond-> (dissoc (:kaocha/cli-options results) :focus)
+                             (= "tests.edn" (:config-file (:kaocha/cli-options results)))
+                             (dissoc :config-file))))
+                  (conj "--focus"
+                        (str
+                         "'" (cond-> id (= (first id) \:) (subs 1)) "'")))))))))
     results))


### PR DESCRIPTION
When invoking with no extra arguments the output of `:print-invocations` would have a stray (double) space. e.g.

```
bin/kaocha  --focus 'kaocha.type.ns-test/run-test-parallel'
-----------^
```

Get rid of that.

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
