### PR TITLE
fix the issue from kaocha #416: casting *out* to System/out

### DIFF
--- a/src/kaocha/api.clj
+++ b/src/kaocha/api.clj
@@ -17,7 +17,8 @@
 ;; Prevent clj-refactor from "cleaning" these from the ns form
 (require 'kaocha.monkey-patch)
 
-(def orig-out *out*)
+(def orig-out System/out)
+(def orig-err System/err)
 
 (def ^:dynamic *active?*
   "Is Kaocha currently active? i.e. loading or runnning tests."
@@ -112,7 +113,7 @@
                                          (count (testable/test-seq-with-skipped test-plan))))
                     (output/warn (str "No tests were found. This may be an issue in your Kaocha test configuration."
                                       " To investigate, check the :test-paths and :ns-patterns keys in tests.edn.")))
-                  (throw+ {:kaocha/early-exit 0 }))
+                  (throw+ {:kaocha/early-exit 0}))
 
                 (when (find-ns 'matcher-combinators.core)
                   (require 'kaocha.matcher-combinators))
@@ -130,6 +131,8 @@
                                       ;; still be in effect.
                                       (System/setOut
                                        orig-out)
+                                      (System/setErr
+                                       orig-err)
                                       (binding [history/*history* history]
                                         (t/do-report (history/clojure-test-summary)))
                                       (catch Throwable t

--- a/src/kaocha/api.clj
+++ b/src/kaocha/api.clj
@@ -17,6 +17,14 @@
 ;; Prevent clj-refactor from "cleaning" these from the ns form
 (require 'kaocha.monkey-patch)
 
+;; Before orig-out was set to *out*, and unfortunately that will
+;; cause a ClassCastException.
+;; => "java.io.OutputStreamWriter cannot be cast to java.io.PrintStream"
+;; Explanation:
+;; The exception is because that when user interruption happens,
+;; Kaocha will force resetting printing to stdout. However, *out*
+;; is of class java.io.OutputStreamWriter, but System/out is of
+;; class java.io.PrintStream
 (def orig-out System/out)
 (def orig-err System/err)
 


### PR DESCRIPTION
# Problem

From #416, there is a bug raised. The bug is because that Clojure's `*out*` is not totally equivalent to java's `System/out`. Clojure's `*out*` is equivalent to System/out, wrapped in an OutputStreamWriter. Therefore, it caused a Casting error. 

# Solution

After referencing how output capture is implemented in `src/kaocha/plugin/capture_output.cljc`, although I think there is already a `finally` section, which should restore the java's `System/out` and `System/err`, I tend to believe that Arne's comment is based on his real world experiments. 

```
;; Force reset printing to stdout, since we
;; don't know where in the process we've
;; been interrupted, output capturing may
;; still be in effect.
```