### PR TITLE
Truncate irrelevant parts of stacktrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Added kaocha.stacktrace/*stacktrace-stop-list* binding to stop printing a stacktrace after matching a string
+
 ## Added
 
 ## Fixed

--- a/doc/config/bindings.md
+++ b/doc/config/bindings.md
@@ -81,14 +81,14 @@ You can configure dynamic vars from `tests.edn`, these will be bound to the
 - <em>Then </em> the output should contain:
 
 ``` nil
-at clojure.lang
+clojure.lang
 ```
 
 
 - <em>And </em> the output should not contain
 
 ``` nil
-at clojure.core
+clojure.core
 ```
 
 
@@ -120,7 +120,7 @@ at clojure.core
 - <em>Then </em> the output should contain:
 
 ``` nil
-at clojure.core
+clojure.core
 ```
 
 
@@ -131,7 +131,7 @@ at clojure.core
 
 ``` clojure
 #kaocha/v1
-{:bindings {kaocha.stacktrace/*stacktrace-stop-list* ["kaocha.ns"]}}
+{:bindings {kaocha.stacktrace/*stacktrace-stop-list* ["kaocha.runner"]}}
 ```
 
 
@@ -159,7 +159,7 @@ at clojure.core
 - <em>And </em> the output should not contain
 
 ``` nil
-at kaocha.ns
+kaocha.runner$
 ```
 
 
@@ -192,7 +192,7 @@ at kaocha.ns
 - <em>Then </em> the output should contain:
 
 ``` nil
-at kaocha.runner
+kaocha.runner$
 ```
 
 

--- a/doc/config/bindings.md
+++ b/doc/config/bindings.md
@@ -71,7 +71,7 @@ You can configure dynamic vars from `tests.edn`, these will be bound to the
   (:require [clojure.test :refer :all]))
 
 (deftest stacktrace-test
-  (is (throw (java.lang.Exception.)))
+  (is (throw (java.lang.Exception.))))
 
 ```
 
@@ -81,14 +81,14 @@ You can configure dynamic vars from `tests.edn`, these will be bound to the
 - <em>Then </em> the output should contain:
 
 ``` nil
-clojure.lang
+at clojure.lang
 ```
 
 
 - <em>And </em> the output should not contain
 
 ``` nil
-clojure.core
+at clojure.core
 ```
 
 
@@ -110,7 +110,7 @@ clojure.core
   (:require [clojure.test :refer :all]))
 
 (deftest stacktrace-test
-  (is (throw (java.lang.Exception.)))
+  (is (throw (java.lang.Exception.))))
 
 ```
 
@@ -120,7 +120,7 @@ clojure.core
 - <em>Then </em> the output should contain:
 
 ``` nil
-clojure.core
+at clojure.core
 ```
 
 
@@ -142,7 +142,7 @@ clojure.core
   (:require [clojure.test :refer :all]))
 
 (deftest stacktrace-test
-  (is (throw (java.lang.Exception.)))
+  (is (throw (java.lang.Exception.))))
 
 ```
 
@@ -159,7 +159,7 @@ clojure.core
 - <em>And </em> the output should not contain
 
 ``` nil
-kaocha.ns
+at kaocha.ns
 ```
 
 
@@ -182,7 +182,7 @@ kaocha.ns
   (:require [clojure.test :refer :all]))
 
 (deftest stacktrace-test
-  (is (throw (java.lang.Exception.)))
+  (is (throw (java.lang.Exception.))))
 
 ```
 
@@ -192,7 +192,7 @@ kaocha.ns
 - <em>Then </em> the output should contain:
 
 ``` nil
-kaocha.runner
+at kaocha.runner
 ```
 
 

--- a/doc/config/bindings.md
+++ b/doc/config/bindings.md
@@ -14,6 +14,8 @@ You can configure dynamic vars from `tests.edn`, these will be bound to the
 
   - `kaocha.stacktrace/*stacktrace-filters* []` disable filtering of
     stacktraces, showing all stack frames
+  - `kaocha.stacktrace/*stacktrace-stop-list* []` disable the shortening
+    of the stacktrace (by default stops printing when it sees "kaocha.ns")
   - `clojure.pprint/*print-right-margin* 120` Make pretty printing use longer
     line lengths
   - `clojure.test.check.clojure-test/*report-completion* false, clojure.test.check.clojure-test/*report-trials* false`
@@ -48,6 +50,156 @@ You can configure dynamic vars from `tests.edn`, these will be bound to the
 
 ``` nil
 1 tests, 1 assertions, 0 failures.
+```
+
+
+
+## Stacktrace filtering
+
+- <em>Given </em> a file named "tests.edn" with:
+
+``` clojure
+#kaocha/v1
+{:bindings {kaocha.stacktrace/*stacktrace-filters* ["clojure.core"]}}
+```
+
+
+- <em>And </em> a file named "test/my/erroring_test.clj" with:
+
+``` clojure
+(ns my.erroring-test
+  (:require [clojure.test :refer :all]))
+
+(deftest stacktrace-test
+  (is (throw (java.lang.Exception.)))
+
+```
+
+
+- <em>When </em> I run `bin/kaocha`
+
+- <em>Then </em> the output should contain:
+
+``` nil
+clojure.lang
+```
+
+
+- <em>And </em> the output should not contain
+
+``` nil
+clojure.core
+```
+
+
+
+## Stacktrace filtering turned off
+
+- <em>Given </em> a file named "tests.edn" with:
+
+``` clojure
+#kaocha/v1
+{:bindings {kaocha.stacktrace/*stacktrace-filters* []}}
+```
+
+
+- <em>And </em> a file named "test/my/erroring_test.clj" with:
+
+``` clojure
+(ns my.erroring-test
+  (:require [clojure.test :refer :all]))
+
+(deftest stacktrace-test
+  (is (throw (java.lang.Exception.)))
+
+```
+
+
+- <em>When </em> I run `bin/kaocha`
+
+- <em>Then </em> the output should contain:
+
+``` nil
+clojure.core
+```
+
+
+
+## Stacktrace shortening
+
+- <em>Given </em> a file named "tests.edn" with:
+
+``` clojure
+#kaocha/v1
+{:bindings {kaocha.stacktrace/*stacktrace-stop-list* ["kaocha.ns"]}}
+```
+
+
+- <em>And </em> a file named "test/my/erroring_test.clj" with:
+
+``` clojure
+(ns my.erroring-test
+  (:require [clojure.test :refer :all]))
+
+(deftest stacktrace-test
+  (is (throw (java.lang.Exception.)))
+
+```
+
+
+- <em>When </em> I run `bin/kaocha`
+
+- <em>Then </em> the output should contain:
+
+``` nil
+(Rest of stacktrace elided)
+```
+
+
+- <em>And </em> the output should not contain
+
+``` nil
+kaocha.ns
+```
+
+
+
+## Disable stacktrace shortening
+
+- <em>Given </em> a file named "tests.edn" with:
+
+``` clojure
+#kaocha/v1
+{:bindings {kaocha.stacktrace/*stacktrace-filters* []
+            kaocha.stacktrace/*stacktrace-stop-list* []}}
+```
+
+
+- <em>And </em> a file named "test/my/erroring_test.clj" with:
+
+``` clojure
+(ns my.erroring-test
+  (:require [clojure.test :refer :all]))
+
+(deftest stacktrace-test
+  (is (throw (java.lang.Exception.)))
+
+```
+
+
+- <em>When </em> I run `bin/kaocha`
+
+- <em>Then </em> the output should contain:
+
+``` nil
+kaocha.runner
+```
+
+
+- <em>And </em> the output should not contain
+
+``` nil
+(Rest of stacktrace elided)
 ```
 
 

--- a/src/kaocha/stacktrace.clj
+++ b/src/kaocha/stacktrace.clj
@@ -7,17 +7,16 @@
                                      "clojure.lang."
                                      "clojure.core"
                                      "clojure.main"
-                                     "orchestra."
                                      "kaocha.monkey_patch"])
 
 (defn elide-element? [e]
   (some #(str/starts-with? (.getClassName ^StackTraceElement e) %) *stacktrace-filters*))
 
-(def sentinel-list ["kaocha.ns"
-                    "lambdaisland.tools.namespace.reload"])
+(def ^:dynamic *stacktrace-stop-list* ["kaocha.ns"
+                                       "lambdaisland.tools.namespace.reload"])
 
 (defn sentinel-element? [e]
-  (some #(str/starts-with? (.getClassName ^StackTraceElement e) %) sentinel-list))
+  (some #(str/starts-with? (.getClassName ^StackTraceElement e) %) *stacktrace-stop-list*))
 
 (defn print-stack-trace
   "Prints a Clojure-oriented stack trace of tr, a Throwable.

--- a/test/features/config/bindings.feature
+++ b/test/features/config/bindings.feature
@@ -53,7 +53,7 @@ Feature: Configuration: Bindings
       (:require [clojure.test :refer :all]))
 
     (deftest stacktrace-test
-      (is (throw (java.lang.Exception.)))
+      (is (throw (java.lang.Exception.))))
     
     """
     When I run `bin/kaocha`
@@ -78,7 +78,7 @@ Feature: Configuration: Bindings
       (:require [clojure.test :refer :all]))
 
     (deftest stacktrace-test
-      (is (throw (java.lang.Exception.)))
+      (is (throw (java.lang.Exception.))))
     
     """
     When I run `bin/kaocha`
@@ -99,7 +99,7 @@ Feature: Configuration: Bindings
       (:require [clojure.test :refer :all]))
 
     (deftest stacktrace-test
-      (is (throw (java.lang.Exception.)))
+      (is (throw (java.lang.Exception.))))
     
     """
     When I run `bin/kaocha`
@@ -125,7 +125,7 @@ Feature: Configuration: Bindings
       (:require [clojure.test :refer :all]))
 
     (deftest stacktrace-test
-      (is (throw (java.lang.Exception.)))
+      (is (throw (java.lang.Exception.))))
     
     """
     When I run `bin/kaocha`

--- a/test/features/config/bindings.feature
+++ b/test/features/config/bindings.feature
@@ -59,11 +59,11 @@ Feature: Configuration: Bindings
     When I run `bin/kaocha`
     Then the output should contain:
     """
-    clojure.lang
+    at clojure.lang
     """
     And the output should not contain
     """
-    clojure.core
+    at clojure.core
     """
 
   Scenario: Stacktrace filtering turned off
@@ -84,7 +84,7 @@ Feature: Configuration: Bindings
     When I run `bin/kaocha`
     Then the output should contain:
     """
-    clojure.core
+    at clojure.core
     """
 
   Scenario: Stacktrace shortening
@@ -109,7 +109,7 @@ Feature: Configuration: Bindings
     """
     And the output should not contain
     """
-    kaocha.ns
+    at kaocha.ns
     """
 
   Scenario: Disable stacktrace shortening
@@ -131,7 +131,7 @@ Feature: Configuration: Bindings
     When I run `bin/kaocha`
     Then the output should contain:
     """
-    kaocha.runner
+    at kaocha.runner
     """
     And the output should not contain
     """

--- a/test/features/config/bindings.feature
+++ b/test/features/config/bindings.feature
@@ -59,11 +59,11 @@ Feature: Configuration: Bindings
     When I run `bin/kaocha`
     Then the output should contain:
     """
-    at clojure.lang
+    clojure.lang
     """
     And the output should not contain
     """
-    at clojure.core
+    clojure.core
     """
 
   Scenario: Stacktrace filtering turned off
@@ -84,14 +84,14 @@ Feature: Configuration: Bindings
     When I run `bin/kaocha`
     Then the output should contain:
     """
-    at clojure.core
+    clojure.core
     """
 
   Scenario: Stacktrace shortening
     Given a file named "tests.edn" with:
     """ clojure
     #kaocha/v1
-    {:bindings {kaocha.stacktrace/*stacktrace-stop-list* ["kaocha.ns"]}}
+    {:bindings {kaocha.stacktrace/*stacktrace-stop-list* ["kaocha.runner"]}}
     """
     And a file named "test/my/erroring_test.clj" with:
     """ clojure
@@ -109,7 +109,7 @@ Feature: Configuration: Bindings
     """
     And the output should not contain
     """
-    at kaocha.ns
+    kaocha.runner
     """
 
   Scenario: Disable stacktrace shortening
@@ -131,7 +131,7 @@ Feature: Configuration: Bindings
     When I run `bin/kaocha`
     Then the output should contain:
     """
-    at kaocha.runner
+    kaocha.runner
     """
     And the output should not contain
     """

--- a/test/features/config/bindings.feature
+++ b/test/features/config/bindings.feature
@@ -109,7 +109,7 @@ Feature: Configuration: Bindings
     """
     And the output should not contain
     """
-    kaocha.runner
+    kaocha.runner$
     """
 
   Scenario: Disable stacktrace shortening
@@ -131,7 +131,7 @@ Feature: Configuration: Bindings
     When I run `bin/kaocha`
     Then the output should contain:
     """
-    kaocha.runner
+    kaocha.runner$
     """
     And the output should not contain
     """

--- a/test/features/config/bindings.feature
+++ b/test/features/config/bindings.feature
@@ -12,6 +12,8 @@ Feature: Configuration: Bindings
 
   - `kaocha.stacktrace/*stacktrace-filters* []` disable filtering of
     stacktraces, showing all stack frames
+  - `kaocha.stacktrace/*stacktrace-stop-list* []` disable the shortening
+    of the stacktrace (by default stops printing when it sees "kaocha.ns")
   - `clojure.pprint/*print-right-margin* 120` Make pretty printing use longer
     line lengths
   - `clojure.test.check.clojure-test/*report-completion* false, clojure.test.check.clojure-test/*report-trials* false`
@@ -37,4 +39,101 @@ Feature: Configuration: Bindings
     Then the output should contain:
     """
     1 tests, 1 assertions, 0 failures.
+    """
+
+  Scenario: Stacktrace filtering
+    Given a file named "tests.edn" with:
+    """ clojure
+    #kaocha/v1
+    {:bindings {kaocha.stacktrace/*stacktrace-filters* ["clojure.core"]}}
+    """
+    And a file named "test/my/erroring_test.clj" with:
+    """ clojure
+    (ns my.erroring-test
+      (:require [clojure.test :refer :all]))
+
+    (deftest stacktrace-test
+      (is (throw (java.lang.Exception.)))
+    
+    """
+    When I run `bin/kaocha`
+    Then the output should contain:
+    """
+    clojure.lang
+    """
+    And the output should not contain
+    """
+    clojure.core
+    """
+
+  Scenario: Stacktrace filtering turned off
+    Given a file named "tests.edn" with:
+    """ clojure
+    #kaocha/v1
+    {:bindings {kaocha.stacktrace/*stacktrace-filters* []}}
+    """
+    And a file named "test/my/erroring_test.clj" with:
+    """ clojure
+    (ns my.erroring-test
+      (:require [clojure.test :refer :all]))
+
+    (deftest stacktrace-test
+      (is (throw (java.lang.Exception.)))
+    
+    """
+    When I run `bin/kaocha`
+    Then the output should contain:
+    """
+    clojure.core
+    """
+
+  Scenario: Stacktrace shortening
+    Given a file named "tests.edn" with:
+    """ clojure
+    #kaocha/v1
+    {:bindings {kaocha.stacktrace/*stacktrace-stop-list* ["kaocha.ns"]}}
+    """
+    And a file named "test/my/erroring_test.clj" with:
+    """ clojure
+    (ns my.erroring-test
+      (:require [clojure.test :refer :all]))
+
+    (deftest stacktrace-test
+      (is (throw (java.lang.Exception.)))
+    
+    """
+    When I run `bin/kaocha`
+    Then the output should contain:
+    """
+    (Rest of stacktrace elided)
+    """
+    And the output should not contain
+    """
+    kaocha.ns
+    """
+
+  Scenario: Disable stacktrace shortening
+    Given a file named "tests.edn" with:
+    """ clojure
+    #kaocha/v1
+    {:bindings {kaocha.stacktrace/*stacktrace-filters* []
+                kaocha.stacktrace/*stacktrace-stop-list* []}}
+    """
+    And a file named "test/my/erroring_test.clj" with:
+    """ clojure
+    (ns my.erroring-test
+      (:require [clojure.test :refer :all]))
+
+    (deftest stacktrace-test
+      (is (throw (java.lang.Exception.)))
+    
+    """
+    When I run `bin/kaocha`
+    Then the output should contain:
+    """
+    kaocha.runner
+    """
+    And the output should not contain
+    """
+    (Rest of stacktrace elided)
     """

--- a/tests.edn
+++ b/tests.edn
@@ -17,6 +17,7 @@
 
  :kaocha.hooks/pre-load [kaocha.assertions/load-assertions]
 
- :kaocha/bindings {kaocha.stacktrace/*stacktrace-filters* []}
+ :kaocha/bindings {kaocha.stacktrace/*stacktrace-filters* []
+                   kaocha.stacktrace/*stacktrace-stop-list* []}
 
  :reporter kaocha.report/documentation}


### PR DESCRIPTION
Resolves #58 

This is directly based on @pesterhazy's PR https://github.com/lambdaisland/kaocha/pull/321

What I've added:
- made the binding dynamic, making it possible to rebind in your tests.edn
- added a line to the docs
- added tests for both existing stacktrace filtering, and stacktrace truncating
- removed [orchestra](https://github.com/jeaye/orchestra) from default stacktrace filtering, since people might use it in their own code (ala @tonsky's [comment](https://github.com/lambdaisland/kaocha/issues/58#issuecomment-458555380))