### PR TITLE
Fix watching when paths don't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Added
 
+- Fix watching when paths do not exist.
+
 ## Fixed
 
 ## Changed

--- a/src/kaocha/watch.clj
+++ b/src/kaocha/watch.clj
@@ -271,13 +271,15 @@ errors as test errors."
                 config))))
 
 (defn watch-paths [config]
-  (into #{}
-        (comp (remove :kaocha.testable/skip)
-              (map (juxt :kaocha/test-paths :kaocha/source-paths))
-              cat
-              cat
-              (map io/file))
-        (:kaocha/tests config)))
+  (->> (into #{}
+             (comp (remove :kaocha.testable/skip)
+                   (map (juxt :kaocha/test-paths :kaocha/source-paths))
+                   cat
+                   cat
+                   (map io/file))
+             (:kaocha/tests config))
+       ;; Without this, if any path doesn't exist the watching doesn't work.
+       (filter (fn [x] (.exists x)))))
 
 (defmulti watch! :type)
 


### PR DESCRIPTION
This fixes a problem where watching silently fails to happen when paths don't exist.

Tests (with `bin/kaocha`) are still passing.