### PR TITLE
Once Fixtures calling f multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Fixed
 
+- Track all results when `:once` fixtures call `f` multiple times.
+  (thanks [@NoahTheDuke](https://github.com/NoahTheDuke))
+
 ## Changed
 
 # 1.87.1366 (2023-09-27 / f514905)

--- a/fixtures/d-tests/ddd/double_once_fixture_test.clj
+++ b/fixtures/d-tests/ddd/double_once_fixture_test.clj
@@ -1,0 +1,17 @@
+(ns ddd.double-once-fixture-test
+  (:require [clojure.test :refer [deftest is use-fixtures]]))
+
+(def ^:dynamic *val* nil)
+
+(defn doubled-fixture [f]
+  (binding [*val* :one]
+    (f))
+  (binding [*val* :two]
+    (f)))
+
+(use-fixtures :once doubled-fixture)
+
+(deftest example-fail-test
+  (if (= :one *val*)
+    (is (= 1 2))
+    (is (= 2 2))))

--- a/src/kaocha/type/ns.clj
+++ b/src/kaocha/type/ns.clj
@@ -16,8 +16,10 @@
 (defn run-tests [testable test-plan fixture-fn]
   ;; It's not guaranteed the the fixture-fn returns the result of calling the
   ;; tests function, so we need to put it in a box for reference.
-  (let [result (atom (:kaocha.test-plan/tests testable))]
-    (fixture-fn #(swap! result testable/run-testables test-plan))
+  (let [testables (:kaocha.test-plan/tests testable)
+        result (atom [])]
+    (fixture-fn #(let [test-result (testable/run-testables testables test-plan)]
+                   (swap! result into test-result)))
     @result))
 
 (defmethod testable/-load :kaocha.type/ns [testable]

--- a/test/unit/kaocha/fixtures_test.clj
+++ b/test/unit/kaocha/fixtures_test.clj
@@ -1,0 +1,45 @@
+(ns kaocha.fixtures-test
+  (:refer-clojure :exclude [symbol])
+  (:require [clojure.test :as t :refer [testing is deftest]]
+            [kaocha.test-factories :as f]
+            [kaocha.testable :as testable]
+            [kaocha.classpath :as classpath]
+            [kaocha.test-helper]
+            [kaocha.core-ext :refer :all]
+            [kaocha.test-util :refer [with-test-ctx]]
+            [kaocha.type.var]
+            [matcher-combinators.test :refer [match?]]))
+
+(deftest once-fixtures-test
+  (classpath/add-classpath "fixtures/d-tests")
+  (testing "once fixture calling f twice"
+    (require 'ddd.double-once-fixture-test)
+    (let [{:keys [result report]}
+          (with-test-ctx {:fail-fast? false}
+            (testable/run {:kaocha.testable/type :kaocha.type/var
+                           :kaocha.testable/id   :ddd.double-once-fixture-test/example-fail-test
+                           :kaocha.testable/desc "example-fail-test"
+                           :kaocha.var/name      'ddd.double-once-fixture-test/example-fail-test
+                           :kaocha.var/var       (resolve 'ddd.double-once-fixture-test/example-fail-test)
+                           :kaocha.var/test      (-> (resolve 'ddd.double-once-fixture-test/example-fail-test) meta :test)}
+                          (f/test-plan {})))]
+
+      (is (match? {:kaocha.testable/type :kaocha.type/var
+                   :kaocha.testable/id   :ddd.double-once-fixture-test/example-fail-test
+                   :kaocha.testable/desc "example-fail-test"
+                   :kaocha.var/name      'ddd.double-once-fixture-test/example-fail-test
+                   :kaocha.var/var       (resolve 'ddd.double-once-fixture-test/example-fail-test)
+                   :kaocha.var/test      fn?
+                   :kaocha.result/count  1
+                   :kaocha.result/pass   0
+                   :kaocha.result/error  0
+                   :kaocha.result/fail   1}
+                  result))
+
+      (is (match? [{:type :begin-test-var}
+                   {:type :pass
+                    :expected '(= 1 2)
+                    :actual '(not (= 1 2))
+                    :message nil}
+                   {:type :end-test-var}]
+                  report)))))

--- a/test/unit/kaocha/fixtures_test.clj
+++ b/test/unit/kaocha/fixtures_test.clj
@@ -16,30 +16,50 @@
     (require 'ddd.double-once-fixture-test)
     (let [{:keys [result report]}
           (with-test-ctx {:fail-fast? false}
-            (testable/run {:kaocha.testable/type :kaocha.type/var
-                           :kaocha.testable/id   :ddd.double-once-fixture-test/example-fail-test
-                           :kaocha.testable/desc "example-fail-test"
-                           :kaocha.var/name      'ddd.double-once-fixture-test/example-fail-test
-                           :kaocha.var/var       (resolve 'ddd.double-once-fixture-test/example-fail-test)
-                           :kaocha.var/test      (-> (resolve 'ddd.double-once-fixture-test/example-fail-test) meta :test)}
+            (testable/run (testable/load {:kaocha.testable/type :kaocha.type/ns
+                                          :kaocha.testable/id   :ddd.double-once-fixture-test
+                                          :kaocha.testable/desc "ddd.double-once-fixture-test"
+                                          :kaocha.ns/name       'ddd.double-once-fixture-test})
                           (f/test-plan {})))]
 
-      (is (match? {:kaocha.testable/type :kaocha.type/var
-                   :kaocha.testable/id   :ddd.double-once-fixture-test/example-fail-test
-                   :kaocha.testable/desc "example-fail-test"
-                   :kaocha.var/name      'ddd.double-once-fixture-test/example-fail-test
-                   :kaocha.var/var       (resolve 'ddd.double-once-fixture-test/example-fail-test)
-                   :kaocha.var/test      fn?
-                   :kaocha.result/count  1
-                   :kaocha.result/pass   0
-                   :kaocha.result/error  0
-                   :kaocha.result/fail   1}
+      (is (match? {:kaocha.testable/type :kaocha.type/ns
+                   :kaocha.testable/id   :ddd.double-once-fixture-test
+                   :kaocha.testable/desc "ddd.double-once-fixture-test"
+                   :kaocha.result/tests
+                   [{:kaocha.testable/type :kaocha.type/var
+                     :kaocha.testable/id   :ddd.double-once-fixture-test/example-fail-test
+                     :kaocha.testable/desc "example-fail-test"
+                     :kaocha.var/name      'ddd.double-once-fixture-test/example-fail-test
+                     :kaocha.var/var       (resolve 'ddd.double-once-fixture-test/example-fail-test)
+                     :kaocha.var/test      fn?
+                     :kaocha.result/count  1
+                     :kaocha.result/pass   0
+                     :kaocha.result/error  0
+                     :kaocha.result/fail   1}
+                    {:kaocha.testable/type :kaocha.type/var
+                     :kaocha.testable/id   :ddd.double-once-fixture-test/example-fail-test
+                     :kaocha.testable/desc "example-fail-test"
+                     :kaocha.var/name      'ddd.double-once-fixture-test/example-fail-test
+                     :kaocha.var/var       (resolve 'ddd.double-once-fixture-test/example-fail-test)
+                     :kaocha.var/test      fn?
+                     :kaocha.result/count  1
+                     :kaocha.result/pass   1
+                     :kaocha.result/error  0
+                     :kaocha.result/fail   0}]}
                   result))
 
-      (is (match? [{:type :begin-test-var}
-                   {:type :pass
+      (is (match? [{:type :begin-test-ns}
+                   {:type :begin-test-var}
+                   {:type :fail
                     :expected '(= 1 2)
                     :actual '(not (= 1 2))
                     :message nil}
-                   {:type :end-test-var}]
-                  report)))))
+                   {:type :end-test-var}
+                   {:type :begin-test-var}
+                   {:type :pass
+                    :expected '(= 2 2)
+                    :actual (list = 2 2)
+                    :message nil}
+                   {:type :end-test-var}
+                   {:type :end-test-ns}]
+                  (mapv #(select-keys % [:type :expected :actual :message]) report))))))


### PR DESCRIPTION
`:once` fixtures that call the provided `f` multiple times can swallow failures if the last call passes. Instead of swapping out the results of the `run-testables` call each time (which discards the existing failures), we should conj all calls together and return that as the completed result.

Related to #388 