### PR TITLE
deep-diff clojure-expectations' `:actual (not=` output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- deep-diff `:actual (not=` output format.
+
 ## Added
 
 ## Fixed

--- a/src/kaocha/report.clj
+++ b/src/kaocha/report.clj
@@ -238,15 +238,24 @@
                    :actual '~form})
     (t/assert-predicate msg form)))
 
+(defmulti get-actual
+  (fn [m] (first (:actual m))))
+
+;; e.g. (not= ...)
+(defmethod get-actual 'not= [m]
+  (-> m :actual))
+
+;; e.g. (not (= ...))
+(defmethod get-actual :default [m]
+  (-> m :actual second))
+
 (defn print-expression [m]
   (let [printer (output/printer)]
-    ;; :actual is of the form (not (= ...))
-
     (if (and (not= (:type m) ::one-arg-eql)
-             (seq? (second (:actual m)))
-             (> (count (second (:actual m))) 2))
+             (seq? (get-actual m))
+             (> (count (get-actual m)) 2))
 
-      (let [[_ expected & actuals] (-> m :actual second)]
+      (let [[_ expected & actuals] (get-actual m)]
         (output/print-doc
          [:span
           "Expected:" :line
@@ -421,7 +430,6 @@
 (defn debug [m]
   (t/with-test-out
     (prn (util/minimal-test-event m))))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/kaocha/report.clj
+++ b/src/kaocha/report.clj
@@ -238,24 +238,24 @@
                    :actual '~form})
     (t/assert-predicate msg form)))
 
-(defmulti get-actual
+(defmulti sexpr-for-diff
   (fn [m] (first (:actual m))))
 
 ;; e.g. (not= ...)
-(defmethod get-actual 'not= [m]
+(defmethod sexpr-for-diff 'not= [m]
   (-> m :actual))
 
 ;; e.g. (not (= ...))
-(defmethod get-actual :default [m]
+(defmethod sexpr-for-diff :default [m]
   (-> m :actual second))
 
 (defn print-expression [m]
   (let [printer (output/printer)]
     (if (and (not= (:type m) ::one-arg-eql)
-             (seq? (get-actual m))
-             (> (count (get-actual m)) 2))
+             (seq? (sexpr-for-diff m))
+             (> (count (sexpr-for-diff m)) 2))
 
-      (let [[_ expected & actuals] (get-actual m)]
+      (let [[_ expected & actuals] (sexpr-for-diff m)]
         (output/print-doc
          [:span
           "Expected:" :line

--- a/test/unit/kaocha/report_test.clj
+++ b/test/unit/kaocha/report_test.clj
@@ -157,6 +157,15 @@
            (report/print-expr {:expected '(= 1 (+ 1 1))
                           :actual '(not (= 1 2))})))))
 
+(deftest print-expression-test
+  (is (= "Expected:\n  [36m1[0m\nActual:\n  [31m-1[0m [32m+2[0m\n"
+         (with-out-str
+           (report/print-expression {:expected '(= 1 (+ 1 1))
+                                     :actual '(not (= 1 2))}))))
+  (is (= "Expected:\n  [36m1[0m\nActual:\n  [31m-1[0m [32m+2[0m\n"
+         (with-out-str
+           (report/print-expression {:expected '(= 1 (+ 1 1))
+                                     :actual '(not= 1 2)})))))
 (deftest fail-summary-test
   (is (= (str   "\n"
                 "[31mFAIL[m in foo/bar-test (foo.clj:42)\n"


### PR DESCRIPTION
`kaocha.report/print-expression` requires `(seq? (second (:actual m)))` to be true to deep-diff output. This is true for `clojure.test`, which outputs `:actual (not (=...`, but not for `clojure-expectations`, whch outputs `:actual (not=...`.

This PR modifies `print-expression` to accept and parse both output formats for deep-diffing.

Resolves https://github.com/lambdaisland/kaocha/issues/435