### PR TITLE
Skip notifier hook test on CI

### DIFF
--- a/test/unit/kaocha/plugin/notifier_test.clj
+++ b/test/unit/kaocha/plugin/notifier_test.clj
@@ -99,7 +99,9 @@
   (is (match? {::n/notifications? false}
               (n/notifier-config-hook {:kaocha/cli-options {:notifications false}}))))
 
-(deftest notifier-post-run-hook-test
+(deftest
+  ^{:kaocha/skip (= "true" (System/getenv "CI"))}
+  notifier-post-run-hook-test
   (let [gen-file-name #(str (System/getProperty "java.io.tmpdir") (System/getProperty "file.separator")
                             (gensym (str (namespace `_) "-" (rand-int 10000))))
         f1 (gen-file-name)


### PR DESCRIPTION
the notifier plugin never does anything on CI, causing this to fail

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
