### PR TITLE
Make bypassing capture context-aware

### DIFF
--- a/src/kaocha/plugin/capture_output.cljc
+++ b/src/kaocha/plugin/capture_output.cljc
@@ -1,13 +1,13 @@
 (ns kaocha.plugin.capture-output
   (:require
-    [clojure.java.io :as io]
-    [kaocha.hierarchy :as hierarchy]
-            [kaocha.plugin :as plugin :refer [defplugin]])
-  (:import (java.io ByteArrayOutputStream
-                    FileOutputStream ;; false positive
-                    OutputStream
-                    PrintStream
-                    PrintWriter)))
+   [kaocha.hierarchy :as hierarchy]
+   [kaocha.plugin :as plugin :refer [defplugin]])
+  (:import
+   (java.io
+    ByteArrayOutputStream
+    OutputStream
+    PrintStream
+    PrintWriter)))
 
 ;; Many props to eftest for much of this code
 
@@ -70,7 +70,7 @@
      (try
        (binding [*out* writer#
                  *err* writer#
-                 *previous-writers* (:previous-writers context#)]
+                 *previous-writers* (or *previous-writers* (:previous-writers context#))]
          (with-redefs [*out* writer#, *err* writer#]
            ~@body))
        (finally


### PR DESCRIPTION
This change makes the `capture/bypass` macro aware of the capture context in which it's running, so that it can more intelligently restore previous out/err writers (or just pass through if no capturing is active).

Unsupported corner cases:
- ~Nested capturing (will write to the next level up, not the original out/err)~
- Code running on other threads where bindings weren't conveyed (will still write to the redef'ed out/err)

If this approach looks sensible, I'm happy to clean up the code, add tests, etc.

Fixes #446