### PR TITLE
Fix test-seq{-with-skipped} with {root,nested} testable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## Fixed
 
 - Fix beholder watch functionality that would cause a NullPointerException earlier.
+- Fix `kaocha.testable/test-seq` not respecting `:kaocha.testable/skip` on root testable
+- Fix `kaocha.testable/test-seq-with-skipped` omitting skipped tests on nested testables
 
 ## Changed
 

--- a/src/kaocha/testable.clj
+++ b/src/kaocha/testable.clj
@@ -228,22 +228,24 @@
         result))))
 
 (defn test-seq [testable]
-  (cond->> (mapcat test-seq (remove ::skip (or (:kaocha/tests testable)
-                                               (:kaocha.test-plan/tests testable)
-                                               (:kaocha.result/tests testable))))
-    ;; When calling test-seq on the top level test-plan/result, don't include
-    ;; the outer map. When running on an actual testable, do include it.
-    (:kaocha.testable/id testable)
-    (cons testable)))
+  (if (::skip testable)
+    ()
+    (cond->> (mapcat test-seq (or (:kaocha/tests testable)
+                                  (:kaocha.test-plan/tests testable)
+                                  (:kaocha.result/tests testable)))
+      ;; When calling test-seq on the top level test-plan/result, don't include
+      ;; the outer map. When running on an actual testable, do include it.
+      (:kaocha.testable/id testable)
+      (cons testable))))
 
 (defn test-seq-with-skipped
-  [testable]
- "Create a seq of all tests, including any skipped tests.
+  "Create a seq of all tests, including any skipped tests.
 
- Typically you want to look at `test-seq` instead."
-  (cond->> (mapcat test-seq (or (:kaocha/tests testable)
-                                               (:kaocha.test-plan/tests testable)
-                                               (:kaocha.result/tests testable)))
+  Typically you want to look at `test-seq` instead."
+  [testable]
+  (cond->> (mapcat test-seq-with-skipped (or (:kaocha/tests testable)
+                                             (:kaocha.test-plan/tests testable)
+                                             (:kaocha.result/tests testable)))
     ;; When calling test-seq on the top level test-plan/result, don't include
     ;; the outer map. When running on an actual testable, do include it.
     (:kaocha.testable/id testable)

--- a/test/unit/kaocha/testable_test.clj
+++ b/test/unit/kaocha/testable_test.clj
@@ -34,14 +34,80 @@
                                        :kaocha.testable/desc "foo"}
                           (f/test-plan {})))))
 
-
 (deftest test-seq-test
-  (is (= (testable/test-seq
-          {:kaocha.testable/id :x/_1
-           :kaocha/tests [{:kaocha.testable/id :y/_1}
-                          {:kaocha.testable/id :z/_1}]})
-         [{:kaocha.testable/id :x/_1,
-           :kaocha/tests [#:kaocha.testable{:id :y/_1}
-                          #:kaocha.testable{:id :z/_1}]}
-          #:kaocha.testable{:id :y/_1}
-          #:kaocha.testable{:id :z/_1}])))
+  (testing "no skipped tests"
+    (is (= (testable/test-seq
+             {:kaocha.testable/id :x/_1
+              :kaocha/tests [{:kaocha.testable/id :y/_1}
+                             {:kaocha.testable/id :z/_1}]})
+           [{:kaocha.testable/id :x/_1,
+             :kaocha/tests [#:kaocha.testable{:id :y/_1}
+                            #:kaocha.testable{:id :z/_1}]}
+            #:kaocha.testable{:id :y/_1}
+            #:kaocha.testable{:id :z/_1}])))
+  (testing "top level test-plan/result is ignored"
+    (is (= (testable/test-seq
+             {:kaocha/tests [{:kaocha.testable/id :y/_1}
+                             {:kaocha.testable/id :z/_1}]})
+           [#:kaocha.testable{:id :y/_1}
+            #:kaocha.testable{:id :z/_1}])))
+  (testing "skipped root testable"
+    (is (= (testable/test-seq
+             {:kaocha.testable/id :x/_1
+              :kaocha.testable/skip true
+              :kaocha/tests [{:kaocha.testable/id :y/_1}
+                             {:kaocha.testable/id :z/_1}]})
+           [])))
+  (testing "skipped nested testable"
+    (is (= (testable/test-seq
+             {:kaocha.testable/id :x/_1
+              :kaocha/tests [{:kaocha.testable/id :y/_1
+                              :kaocha.testable/skip true}
+                             {:kaocha.testable/id :z/_1}]})
+           [{:kaocha.testable/id :x/_1,
+             :kaocha/tests [#:kaocha.testable{:id :y/_1
+                                              :skip true}
+                            #:kaocha.testable{:id :z/_1}]}
+            #:kaocha.testable{:id :z/_1}]))))
+
+(deftest test-seq-with-skipped-test
+  (testing "no skipped tests"
+    (is (= (testable/test-seq-with-skipped
+             {:kaocha.testable/id :x/_1
+              :kaocha/tests [{:kaocha.testable/id :y/_1}
+                             {:kaocha.testable/id :z/_1}]})
+           [{:kaocha.testable/id :x/_1,
+             :kaocha/tests [#:kaocha.testable{:id :y/_1}
+                            #:kaocha.testable{:id :z/_1}]}
+            #:kaocha.testable{:id :y/_1}
+            #:kaocha.testable{:id :z/_1}])))
+  (testing "top level test-plan/result is ignored"
+    (is (= (testable/test-seq-with-skipped
+             {:kaocha/tests [{:kaocha.testable/id :y/_1}
+                             {:kaocha.testable/id :z/_1}]})
+           [#:kaocha.testable{:id :y/_1}
+            #:kaocha.testable{:id :z/_1}])))
+  (testing "skipped outer testable"
+    (is (= (testable/test-seq-with-skipped
+             {:kaocha.testable/id :x/_1
+              :kaocha.testable/skip true
+              :kaocha/tests [{:kaocha.testable/id :y/_1}
+                             {:kaocha.testable/id :z/_1}]})
+           [{:kaocha.testable/id :x/_1,
+             :kaocha.testable/skip true
+             :kaocha/tests [#:kaocha.testable{:id :y/_1}
+                            #:kaocha.testable{:id :z/_1}]}
+            #:kaocha.testable{:id :y/_1}
+            #:kaocha.testable{:id :z/_1}])))
+  (testing "skipped nested testable"
+    (is (= (testable/test-seq-with-skipped
+             {:kaocha.testable/id :x/_1
+              :kaocha/tests [{:kaocha.testable/id :y/_1
+                              :kaocha.testable/skip true}
+                             {:kaocha.testable/id :z/_1}]})
+           [{:kaocha.testable/id :x/_1,
+             :kaocha/tests
+             [#:kaocha.testable{:id :y/_1, :skip true}
+              #:kaocha.testable{:id :z/_1}]}
+            #:kaocha.testable{:id :y/_1, :skip true}
+            #:kaocha.testable{:id :z/_1}]))))


### PR DESCRIPTION
`test-seq` seems to ignore whether the outer testable is skipped, and `test-seq-with-skipped` omits skipped tests if they are nested.