### PR TITLE
Don't warn if side-effecting `main` hook returns nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Fixed
 
 - Fix beholder watch functionality that would cause a NullPointerException earlier.
+- Don't warn if side-effecting `main` hook returns nil.
 
 ## Changed
 

--- a/doc/09_extending.md
+++ b/doc/09_extending.md
@@ -191,13 +191,11 @@ The [hooks chapter](10_hooks.md) has more information about most of these hooks.
   ;; Runs right before kaocha.runner calls kaocha.api/run. This is for plugins
   ;; that optionally do something else besides running tests, like printing
   ;; informational messages and then exiting. For this throw+ a
-  ;; {:kaocha/early-exit}.
+  ;; {:kaocha/early-exit}. Ignores return value.
   (main [config]
-    (if (:do-other-thing (:kaocha/cli-options config))
-      (do
-        (... do other thing ...)
-        (throw+ {:kaocha/early-exit 0}))
-      config))
+    (when (:do-other-thing (:kaocha/cli-options config))
+      (... do other thing ...)
+      (throw+ {:kaocha/early-exit 0})))
 
   ;; Gets called after the run is finished and the summary has been printed/reported.
   ;; Gets passed the test result map (test plan with results).

--- a/src/kaocha/plugin.clj
+++ b/src/kaocha/plugin.clj
@@ -89,8 +89,9 @@
   (reduce (fn [value plugin]
             (if-let [step-fn (get plugin step)]
               (let [value (apply step-fn value extra-args)]
-                (when (nil? value)
-                  (output/warn "Plugin " (:kaocha.plugin/id plugin) " hook " step " returned nil."))
+                (when-not (= :kaocha.hooks/main step) ;; side-effects only
+                  (when (nil? value)
+                    (output/warn "Plugin " (:kaocha.plugin/id plugin) " hook " step " returned nil.")))
                 value)
               value))
           value


### PR DESCRIPTION
If I understand correctly, the `main` hook's return value is ignored.