### PR TITLE
Make `kaocha.jit/jit` thread-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Fixed
 
 - Fix beholder watch functionality that would cause a NullPointerException earlier.
+- Make `kaocha.jit/jit` thread-safe in Clojure 1.10+. For lower versions, best effort with printed warning.
 
 ## Changed
 

--- a/src/kaocha/jit.clj
+++ b/src/kaocha/jit.clj
@@ -4,5 +4,10 @@
   "Just in time loading of dependencies."
   [sym]
   `(do
-     (require '~(symbol (namespace sym)))
+     (locking ~(if (find-var 'clojure.core/requiring-resolve)
+                 'clojure.lang.RT/REQUIRE_LOCK
+                 (do (binding [*err* *out*]
+                       (println "WARNING: kaocha.jit is not thread-safe before Clojure 1.10"))
+                     ::lock))
+       (require '~(symbol (namespace sym))))
      (find-var '~sym)))


### PR DESCRIPTION
Ensures we don't race with other requiring threads.

Note this is now safer than `requiring-resolve` (as of Clojure 1.12), which has a race condition making it prone to returning a partially initialized var.